### PR TITLE
올바른 세션만 통과할 수 있는 api 구현

### DIFF
--- a/src/main/java/com/nubble/backend/config/WebMvcConfig.java
+++ b/src/main/java/com/nubble/backend/config/WebMvcConfig.java
@@ -1,12 +1,18 @@
 package com.nubble.backend.config;
 
+import com.nubble.backend.interceptor.session.SessionCheckInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class CorsConfig {
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final SessionCheckInterceptor sessionCheckInterceptor;
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
@@ -20,5 +26,11 @@ public class CorsConfig {
                         .allowCredentials(true);
             }
         };
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(sessionCheckInterceptor)
+                .addPathPatterns("/**");
     }
 }

--- a/src/main/java/com/nubble/backend/config/properties/SessionCookieProperties.java
+++ b/src/main/java/com/nubble/backend/config/properties/SessionCookieProperties.java
@@ -1,4 +1,4 @@
-package com.nubble.backend.session.controller;
+package com.nubble.backend.config.properties;
 
 import java.time.Duration;
 import lombok.Getter;

--- a/src/main/java/com/nubble/backend/interceptor/session/SessionCheckInterceptor.java
+++ b/src/main/java/com/nubble/backend/interceptor/session/SessionCheckInterceptor.java
@@ -1,6 +1,6 @@
 package com.nubble.backend.interceptor.session;
 
-import com.nubble.backend.session.controller.SessionCookieProperties;
+import com.nubble.backend.config.properties.SessionCookieProperties;
 import com.nubble.backend.session.service.SessionService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/nubble/backend/interceptor/session/SessionCheckInterceptor.java
+++ b/src/main/java/com/nubble/backend/interceptor/session/SessionCheckInterceptor.java
@@ -1,0 +1,43 @@
+package com.nubble.backend.interceptor.session;
+
+import com.nubble.backend.session.controller.SessionCookieProperties;
+import com.nubble.backend.session.service.SessionService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionCheckInterceptor implements HandlerInterceptor {
+
+    private final SessionCookieProperties sessionCookieProperties;
+    private final SessionService sessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (handler instanceof HandlerMethod handlerMethod) {
+            SessionRequired sessionRequired = handlerMethod.getMethodAnnotation(SessionRequired.class);
+            if (sessionRequired != null) {
+                String sessionId = getSessionIdFromCookie(request);
+                sessionService.validateSession(sessionId);
+            }
+        }
+        return true;
+    }
+
+    private String getSessionIdFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (sessionCookieProperties.getName().equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/nubble/backend/interceptor/session/SessionRequired.java
+++ b/src/main/java/com/nubble/backend/interceptor/session/SessionRequired.java
@@ -1,0 +1,12 @@
+package com.nubble.backend.interceptor.session;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionRequired {
+
+}

--- a/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
+++ b/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +39,10 @@ public class SessionApiController {
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, sessionCookie.toString())
                 .build();
+    }
+
+    @GetMapping("/validate")
+    public ResponseEntity<Void> validateSession() {
+        throw new UnsupportedOperationException("아직 구현되지 않았습니다.");
     }
 }

--- a/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
+++ b/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.session.controller;
 
+import com.nubble.backend.interceptor.session.SessionRequired;
 import com.nubble.backend.session.controller.SessionRequest.SessionIssueRequest;
 import com.nubble.backend.session.service.SessionCommand.SessionCreateCommand;
 import com.nubble.backend.session.service.SessionInfo;
@@ -41,8 +42,9 @@ public class SessionApiController {
                 .build();
     }
 
+    @SessionRequired
     @GetMapping("/validate")
     public ResponseEntity<Void> validateSession() {
-        throw new UnsupportedOperationException("아직 구현되지 않았습니다.");
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
+++ b/src/main/java/com/nubble/backend/session/controller/SessionApiController.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.session.controller;
 
+import com.nubble.backend.config.properties.SessionCookieProperties;
 import com.nubble.backend.interceptor.session.SessionRequired;
 import com.nubble.backend.session.controller.SessionRequest.SessionIssueRequest;
 import com.nubble.backend.session.service.SessionCommand.SessionCreateCommand;

--- a/src/main/java/com/nubble/backend/session/service/SessionService.java
+++ b/src/main/java/com/nubble/backend/session/service/SessionService.java
@@ -30,4 +30,13 @@ public class SessionService {
 
         return SessionInfo.fromDomain(newSession);
     }
+
+    public void validateSession(String sessionId) {
+        if (sessionId == null) {
+            throw new RuntimeException("세션이 존재하지 않습니다.");
+        }
+        if (sessionRepository.findByAccessId(sessionId).isEmpty()) {
+            throw new RuntimeException("유효하지 않은 세션입니다.");
+        }
+    }
 }

--- a/src/main/java/com/nubble/backend/session/service/SessionService.java
+++ b/src/main/java/com/nubble/backend/session/service/SessionService.java
@@ -31,11 +31,12 @@ public class SessionService {
         return SessionInfo.fromDomain(newSession);
     }
 
-    public void validateSession(String sessionId) {
-        if (sessionId == null) {
+    @Transactional(readOnly = true)
+    public void validateSession(String sessionAccessId) {
+        if (sessionAccessId == null) {
             throw new RuntimeException("세션이 존재하지 않습니다.");
         }
-        if (sessionRepository.findByAccessId(sessionId).isEmpty()) {
+        if (sessionRepository.findByAccessId(sessionAccessId).isEmpty()) {
             throw new RuntimeException("유효하지 않은 세션입니다.");
         }
     }

--- a/src/test/java/com/nubble/backend/session/controller/SessionApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/session/controller/SessionApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.nubble.backend.session.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -11,6 +12,7 @@ import com.nubble.backend.session.controller.SessionRequest.SessionIssueRequest;
 import com.nubble.backend.session.service.SessionCommand.SessionCreateCommand;
 import com.nubble.backend.session.service.SessionInfo;
 import com.nubble.backend.session.service.SessionService;
+import jakarta.servlet.http.Cookie;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,6 +68,20 @@ class SessionApiControllerTest {
         mockMvc.perform(requestBuilder)
                 .andExpect(status().isOk())
                 .andExpect(cookie().value(sessionCookieProperties.getName(), sessionId))
+                .andDo(print());
+    }
+
+    @DisplayName("유효한 세션을 가지고 있을 경우, ok를 반환합니다.")
+    @Test
+    void validateSession() throws Exception {
+        // given
+        String validSessionId = UUID.randomUUID().toString();
+        MockHttpServletRequestBuilder requestBuilder = get("/sessions/validate")
+                .cookie(new Cookie(sessionCookieProperties.getName(), validSessionId));
+
+        // when & then
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/nubble/backend/session/controller/SessionApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/session/controller/SessionApiControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.config.properties.SessionCookieProperties;
 import com.nubble.backend.session.controller.SessionRequest.SessionIssueRequest;
 import com.nubble.backend.session.service.SessionCommand.SessionCreateCommand;
 import com.nubble.backend.session.service.SessionInfo;

--- a/src/test/java/com/nubble/backend/session/service/SessionServiceTest.java
+++ b/src/test/java/com/nubble/backend/session/service/SessionServiceTest.java
@@ -1,6 +1,7 @@
 package com.nubble.backend.session.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 
 import com.nubble.backend.session.domain.Session;
@@ -63,5 +64,28 @@ class SessionServiceTest {
                     assertThat(byAccessId).isPresent();
                     assertThat(byAccessId.get().getAccessId()).isEqualTo(newSessionId);
                 });
+    }
+
+    @DisplayName("유효한 세션의 accessId이라면 아무런 예외도 발생하지 않습니다.")
+    @Test
+    void validateSession_success() {
+        // given
+        User user = User.builder()
+                .username("user")
+                .password("1234")
+                .build();
+        userRepository.save(user);
+
+        String validSessionAccessId = UUID.randomUUID().toString();
+        Session session = Session.builder()
+                .user(user)
+                .accessId(validSessionAccessId)
+                .build();
+        sessionRepository.save(session);
+
+        // when & then
+        assertThatCode(() ->
+                sessionService.validateSession(validSessionAccessId))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
### 요청

```http
GET /sessions/validate HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/3.2.2
cookie: SESSION=bfefaf0d-c007-4df6-b976-ca6576ce24bd
origin: http://localhost:3000
```

### 응답

```http
HTTP/1.1 200
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://localhost:3000
Connection: keep-alive
Content-Length: 0
Date: Fri, 20 Sep 2024 13:07:07 GMT
Keep-Alive: timeout=60
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
```