### PR TITLE
코딩테스트 문제 등록 및 삭제와 모든 문제 가져오기 엔드포인트 구현

### DIFF
--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -2,7 +2,11 @@ package com.nubble.backend.codingproblem.controller;
 
 import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
 import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemCreateResponse;
+import com.nubble.backend.codingproblem.service.CodingProblemService;
+import com.nubble.backend.config.resolver.UserSession;
+import com.nubble.backend.interceptor.session.SessionRequired;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,15 +17,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/coding-problems")
+@RequiredArgsConstructor
 public class CodingProblemApiController {
 
+    private final CodingProblemService problemService;
+    private final CodingProblemCommandMapper problemCommandMapper;
+
+    @SessionRequired
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ProblemCreateResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
+    public ResponseEntity<ProblemCreateResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request,
+            UserSession userSession) {
+        Long problemId = problemService.createProblem(problemCommandMapper.of(request, userSession.userId()));
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ProblemCreateResponse.builder()
-                        .problemId(1L)
+                        .problemId(problemId)
                         .build());
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -2,15 +2,20 @@ package com.nubble.backend.codingproblem.controller;
 
 import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
 import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemCreateResponse;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemGetResponse;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemGetResponses;
 import com.nubble.backend.codingproblem.service.CodingProblemService;
 import com.nubble.backend.config.resolver.UserSession;
 import com.nubble.backend.interceptor.session.SessionRequired;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +49,24 @@ public class CodingProblemApiController {
         problemService.deleteProblem(problemCommandMapper.of(problemId, userSession.userId()));
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<ProblemGetResponses> getAllProblems() {
+        ProblemGetResponse problem1 = ProblemGetResponse.builder()
+                .problemId(1L)
+                .quizDate(LocalDate.now())
+                .problemTitle("LV.2 귤 까먹기")
+                .build();
+        ProblemGetResponse problem2 = ProblemGetResponse.builder()
+                .problemId(2L)
+                .quizDate(LocalDate.now())
+                .problemTitle("LV.2 귤 까먹기")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ProblemGetResponses.builder()
+                        .problems(List.of(problem1, problem2))
+                        .build());
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -41,6 +41,7 @@ public class CodingProblemApiController {
     @SessionRequired
     @DeleteMapping("/{problemId}")
     public ResponseEntity<Void> deleteProblem(@PathVariable Long problemId, UserSession userSession) {
+        problemService.deleteProblem(problemId, userSession.userId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
     }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +36,12 @@ public class CodingProblemApiController {
                 .body(ProblemCreateResponse.builder()
                         .problemId(problemId)
                         .build());
+    }
+
+    @SessionRequired
+    @DeleteMapping("/{problemId}")
+    public ResponseEntity<Void> deleteProblem(@PathVariable Long problemId, UserSession userSession) {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -41,7 +41,7 @@ public class CodingProblemApiController {
     @SessionRequired
     @DeleteMapping("/{problemId}")
     public ResponseEntity<Void> deleteProblem(@PathVariable Long problemId, UserSession userSession) {
-        problemService.deleteProblem(problemId, userSession.userId());
+        problemService.deleteProblem(problemCommandMapper.of(problemId, userSession.userId()));
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
     }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemApiController.java
@@ -1,0 +1,27 @@
+package com.nubble.backend.codingproblem.controller;
+
+import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemCreateResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/coding-problems")
+public class CodingProblemApiController {
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ProblemCreateResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ProblemCreateResponse.builder()
+                        .problemId(1L)
+                        .build());
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemCommandMapper.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemCommandMapper.java
@@ -1,0 +1,17 @@
+package com.nubble.backend.codingproblem.controller;
+
+import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
+import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface CodingProblemCommandMapper {
+
+    ProblemCreateCommand of(ProblemCreateRequest request, long userId);
+}

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemCommandMapper.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemCommandMapper.java
@@ -2,6 +2,7 @@ package com.nubble.backend.codingproblem.controller;
 
 import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
 import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemDeleteCommand;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -13,5 +14,8 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface CodingProblemCommandMapper {
 
+    // todo of 메소드명에 대해서 생각해보기, of이고 같은 매개인자가 들어오지만, 다른 객체 반환을 원하면 문제 발생
     ProblemCreateCommand of(ProblemCreateRequest request, long userId);
+
+    ProblemDeleteCommand of(Long problemId, long userId);
 }

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemRequest.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemRequest.java
@@ -1,0 +1,28 @@
+package com.nubble.backend.codingproblem.controller;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CodingProblemRequest {
+
+    @Builder
+    public record ProblemCreateRequest(
+            @DateTimeFormat(iso = ISO.DATE)
+            LocalDate quizDate,
+
+            @NotBlank
+            String problemTitle,
+
+            @URL(protocol = "https")
+            String problemUrl
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemResponse.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemResponse.java
@@ -1,0 +1,16 @@
+package com.nubble.backend.codingproblem.controller;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CodingProblemResponse {
+
+    @Builder
+    public record ProblemCreateResponse(
+            long problemId
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemResponse.java
+++ b/src/main/java/com/nubble/backend/codingproblem/controller/CodingProblemResponse.java
@@ -1,5 +1,7 @@
 package com.nubble.backend.codingproblem.controller;
 
+import java.time.LocalDate;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,22 @@ public class CodingProblemResponse {
     @Builder
     public record ProblemCreateResponse(
             long problemId
+    ) {
+
+    }
+
+    @Builder
+    public record ProblemGetResponse(
+            long problemId,
+            LocalDate quizDate,
+            String problemTitle
+    ) {
+
+    }
+
+    @Builder
+    public record ProblemGetResponses(
+            List<ProblemGetResponse> problems
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/codingproblem/domain/CodingProblem.java
+++ b/src/main/java/com/nubble/backend/codingproblem/domain/CodingProblem.java
@@ -1,0 +1,49 @@
+package com.nubble.backend.codingproblem.domain;
+
+import com.nubble.backend.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "coding_problems")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CodingProblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate quizDate;
+
+    @Column(nullable = false)
+    String title;
+
+    @Column(nullable = false)
+    String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public CodingProblem(LocalDate quizDate, String title, String url, User user) {
+        this.quizDate = quizDate;
+        this.title = title;
+        this.url = url;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemCommand.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemCommand.java
@@ -13,8 +13,14 @@ public class CodingProblemCommand {
             Long userId,
             LocalDate quizDate,
             String problemTitle,
-            String problemUrl
-    ) {
+            String problemUrl) {
+        
+    }
+
+    @Builder
+    public record ProblemDeleteCommand(
+            Long userId,
+            Long problemId) {
 
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemCommand.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemCommand.java
@@ -1,0 +1,20 @@
+package com.nubble.backend.codingproblem.service;
+
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CodingProblemCommand {
+
+    @Builder
+    public record ProblemCreateCommand(
+            Long userId,
+            LocalDate quizDate,
+            String problemTitle,
+            String problemUrl
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemInfo.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemInfo.java
@@ -1,0 +1,23 @@
+package com.nubble.backend.codingproblem.service;
+
+import com.nubble.backend.codingproblem.domain.CodingProblem;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record CodingProblemInfo(
+        long problemId,
+        LocalDate quizDate,
+        String problemTitle,
+        String url
+) {
+
+    public static CodingProblemInfo fromDomain(CodingProblem problem) {
+        return CodingProblemInfo.builder()
+                .problemId(problem.getId())
+                .quizDate(problem.getQuizDate())
+                .problemTitle(problem.getTitle())
+                .url(problem.getUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemRepository.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemRepository.java
@@ -1,0 +1,8 @@
+package com.nubble.backend.codingproblem.service;
+
+import com.nubble.backend.codingproblem.domain.CodingProblem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CodingProblemRepository extends JpaRepository<CodingProblem, Long> {
+
+}

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
@@ -6,6 +6,7 @@ import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemDele
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -42,5 +43,11 @@ public class CodingProblemService {
             throw new RuntimeException("문제를 등록한 사람만 삭제할 수 있습니다.");
         }
         problemRepository.delete(problem);
+    }
+
+    public List<CodingProblemInfo> findAllProblems() {
+        return problemRepository.findAll().stream()
+                .map(CodingProblemInfo::fromDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
@@ -5,6 +5,7 @@ import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCrea
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,5 +30,16 @@ public class CodingProblemService {
                 .build();
 
         return problemRepository.save(newProblem).getId();
+    }
+
+    @Transactional
+    public void deleteProblem(Long problemId, Long userId) {
+        CodingProblem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new EntityNotFoundException("코딩테스트 문제가 존재하지 않습니다."));
+
+        if (!Objects.equals(problem.getUser().getId(), userId)) {
+            throw new RuntimeException("문제를 등록한 사람만 삭제할 수 있습니다.");
+        }
+        problemRepository.delete(problem);
     }
 }

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
@@ -1,0 +1,33 @@
+package com.nubble.backend.codingproblem.service;
+
+import com.nubble.backend.codingproblem.domain.CodingProblem;
+import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+import com.nubble.backend.user.domain.User;
+import com.nubble.backend.user.service.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CodingProblemService {
+
+    private final CodingProblemRepository problemRepository;
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createProblem(ProblemCreateCommand command) {
+        User user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new EntityNotFoundException("유저가 존재하지 않습니다."));
+        CodingProblem newProblem = CodingProblem.builder()
+                .quizDate(command.quizDate())
+                .title(command.problemTitle())
+                .url(command.problemUrl())
+                .user(user)
+                .build();
+
+        return problemRepository.save(newProblem).getId();
+    }
+}

--- a/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
+++ b/src/main/java/com/nubble/backend/codingproblem/service/CodingProblemService.java
@@ -2,6 +2,7 @@ package com.nubble.backend.codingproblem.service;
 
 import com.nubble.backend.codingproblem.domain.CodingProblem;
 import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemDeleteCommand;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -33,11 +34,11 @@ public class CodingProblemService {
     }
 
     @Transactional
-    public void deleteProblem(Long problemId, Long userId) {
-        CodingProblem problem = problemRepository.findById(problemId)
+    public void deleteProblem(ProblemDeleteCommand command) {
+        CodingProblem problem = problemRepository.findById(command.problemId())
                 .orElseThrow(() -> new EntityNotFoundException("코딩테스트 문제가 존재하지 않습니다."));
 
-        if (!Objects.equals(problem.getUser().getId(), userId)) {
+        if (!Objects.equals(problem.getUser().getId(), command.userId())) {
             throw new RuntimeException("문제를 등록한 사람만 삭제할 수 있습니다.");
         }
         problemRepository.delete(problem);

--- a/src/main/java/com/nubble/backend/config/resolver/UserSession.java
+++ b/src/main/java/com/nubble/backend/config/resolver/UserSession.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record UserSession(
-        long userId,
+        long userId, // todo 호환성을 위해 Long으로 수정
         String sessionId
 ) {
 

--- a/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.nubble.backend.codingproblem.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,7 +52,7 @@ class CodingProblemApiControllerTest {
     @Autowired
     private UserRepository userRepository;
 
-    @DisplayName("코딩테스트 문제를 생성한다.")
+    @DisplayName("로그인한 유저가 코딩테스트 문제를 등록한다.")
     @Test
     void createProblem_success() throws Exception {
         // given
@@ -90,5 +91,28 @@ class CodingProblemApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(responseJson));
+    }
+
+    @DisplayName("로그인한 유저가 코딩테스트 문제를 삭제한다.")
+    @Test
+    void test() throws Exception {
+        // given
+        // todo UserSession 발급의 중복이 발생, 한 번에 처리하는 클래스 필요
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+        Session session = Session.builder()
+                .user(user)
+                .accessId(UUID.randomUUID().toString())
+                .expireAt(LocalDateTime.now().plusDays(1))
+                .build();
+        sessionRepository.save(session);
+
+        Long problemId = 1L;
+        MockHttpServletRequestBuilder requestBuilder = delete("/coding-problems/{problemId}", problemId)
+                .header("SESSION-ID", session.getAccessId());
+
+        // when & then
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
@@ -1,0 +1,55 @@
+package com.nubble.backend.codingproblem.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemCreateResponse;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CodingProblemApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("코딩테스트 문제를 생성한다.")
+    @Test
+    void createProblem_success() throws Exception {
+        // given
+        ProblemCreateRequest request = ProblemCreateRequest.builder()
+                .quizDate(LocalDate.now())
+                .problemTitle("새로운 문제")
+                .problemUrl("https:")
+                .build();
+
+        MockHttpServletRequestBuilder requestBuilder = post("/coding-problems")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request));
+
+        ProblemCreateResponse expectedResponse = ProblemCreateResponse.builder()
+                .problemId(1L)
+                .build();
+        String responseJson = objectMapper.writeValueAsString(expectedResponse);
+
+        // when & then
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(responseJson));
+    }
+}

--- a/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/controller/CodingProblemApiControllerTest.java
@@ -2,13 +2,17 @@ package com.nubble.backend.codingproblem.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nubble.backend.codingproblem.controller.CodingProblemRequest.ProblemCreateRequest;
 import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemCreateResponse;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemGetResponse;
+import com.nubble.backend.codingproblem.controller.CodingProblemResponse.ProblemGetResponses;
 import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
 import com.nubble.backend.codingproblem.service.CodingProblemService;
 import com.nubble.backend.fixture.UserFixture;
@@ -18,6 +22,7 @@ import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,7 +95,8 @@ class CodingProblemApiControllerTest {
         mockMvc.perform(requestBuilder)
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().json(responseJson));
+                .andExpect(content().json(responseJson))
+                .andDo(print());
     }
 
     @DisplayName("로그인한 유저가 코딩테스트 문제를 삭제한다.")
@@ -113,6 +119,35 @@ class CodingProblemApiControllerTest {
 
         // when & then
         mockMvc.perform(requestBuilder)
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    @DisplayName("비회원도 모든 코딩테스트 문제들을 가져올 수 있다.")
+    @Test
+    void getAllProblems() throws Exception {
+        // given
+        ProblemGetResponse problem1 = ProblemGetResponse.builder()
+                .problemId(1L)
+                .quizDate(LocalDate.now())
+                .problemTitle("LV.2 귤 까먹기")
+                .build();
+        ProblemGetResponse problem2 = ProblemGetResponse.builder()
+                .problemId(2L)
+                .quizDate(LocalDate.now())
+                .problemTitle("LV.2 귤 까먹기")
+                .build();
+        ProblemGetResponses response = ProblemGetResponses.builder()
+                .problems(List.of(problem1, problem2))
+                .build();
+        String responseJson = objectMapper.writeValueAsString(response);
+
+        MockHttpServletRequestBuilder requilestBuilder = get("/coding-problems");
+
+        // when & then
+        mockMvc.perform(requilestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
@@ -1,6 +1,7 @@
 package com.nubble.backend.codingproblem.service;
 
 import static com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.user.domain.User;
@@ -45,5 +46,25 @@ class CodingProblemServiceTest {
 
         // then
         Assertions.assertThat(problemRepository.findById(newProblemId)).isPresent();
+    }
+
+    @DisplayName("문제를 등록한 사람은 문제를 삭제할 수 있습니다.")
+    @Test
+    void deleteProblem() {
+        // given
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        ProblemCreateCommand command = ProblemCreateCommand.builder()
+                .quizDate(LocalDate.now())
+                .problemTitle("할로윈의 양아치")
+                .problemUrl("https://www.acmicpc.net/problem/20303")
+                .userId(user.getId())
+                .build();
+        Long problemId = problemService.createProblem(command);
+
+        // when & then
+        assertThatCode(() -> problemService.deleteProblem(problemId, user.getId()))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
@@ -3,6 +3,7 @@ package com.nubble.backend.codingproblem.service;
 import static com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
+import com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemDeleteCommand;
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
@@ -55,16 +56,20 @@ class CodingProblemServiceTest {
         User user = UserFixture.aUser().build();
         userRepository.save(user);
 
-        ProblemCreateCommand command = ProblemCreateCommand.builder()
+        Long problemId = problemService.createProblem(ProblemCreateCommand.builder()
                 .quizDate(LocalDate.now())
                 .problemTitle("할로윈의 양아치")
                 .problemUrl("https://www.acmicpc.net/problem/20303")
                 .userId(user.getId())
+                .build());
+
+        ProblemDeleteCommand command = ProblemDeleteCommand.builder()
+                .problemId(problemId)
+                .userId(user.getId())
                 .build();
-        Long problemId = problemService.createProblem(command);
 
         // when & then
-        assertThatCode(() -> problemService.deleteProblem(problemId, user.getId()))
+        assertThatCode(() -> problemService.deleteProblem(command))
                 .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
+++ b/src/test/java/com/nubble/backend/codingproblem/service/CodingProblemServiceTest.java
@@ -1,0 +1,49 @@
+package com.nubble.backend.codingproblem.service;
+
+import static com.nubble.backend.codingproblem.service.CodingProblemCommand.ProblemCreateCommand;
+
+import com.nubble.backend.fixture.UserFixture;
+import com.nubble.backend.user.domain.User;
+import com.nubble.backend.user.service.UserRepository;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CodingProblemServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CodingProblemService problemService;
+
+    @Autowired
+    private CodingProblemRepository problemRepository;
+
+    @DisplayName("코딩 테스트 문제를 생성합니다.")
+    @Test
+    void createProblem_success() {
+        // given
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        ProblemCreateCommand command = ProblemCreateCommand.builder()
+                .quizDate(LocalDate.now())
+                .problemTitle("할로윈의 양아치")
+                .problemUrl("https://www.acmicpc.net/problem/20303")
+                .userId(user.getId())
+                .build();
+
+        // when
+        Long newProblemId = problemService.createProblem(command);
+
+        // then
+        Assertions.assertThat(problemRepository.findById(newProblemId)).isPresent();
+    }
+}


### PR DESCRIPTION
## 코딩테스트 문제 등록 API

### 요청
```http
POST /coding-problems HTTP/1.1
Host: api-domain.com
Content-Type: application/json
SESSION-ID: 123e4567-e89b-12d3-a456-426614174000

{
  "quizDate": "2024-09-28",
  "problemTitle": "두 수의 합 구하기",
  "problemUrl": "https://example.com/problem/123"
}
```

### 응답
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
  "problemId": 12345
}
```

## 코딩테스트 문제 삭제

### 요청
```http
DELETE /coding-problems/12345 HTTP/1.1
Host: api-domain.com
SESSION-ID: 123e4567-e89b-12d3-a456-426614174000
```

### 응답
```http
HTTP/1.1 204 No Content
```

## 모든 코딩 테스트 문제 가져오기

### 요청
```http
GET /coding-problems HTTP/1.1
Host: api-domain.com
```

### 응답
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
  "problems": [
    {
      "problemId": 1,
      "quizDate": "2024-09-28",
      "problemTitle": "LV.2 귤 까먹기"
    },
    {
      "problemId": 2,
      "quizDate": "2024-09-28",
      "problemTitle": "LV.2 귤 까먹기"
    }
  ]
}
```