### PR TITLE
feature: 게시글 등록 및 게시 기능 구현

### DIFF
--- a/src/main/java/com/nubble/backend/post/controller/PostApiController.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostApiController.java
@@ -34,9 +34,7 @@ public class PostApiController {
         PostCreateCommand command = postCommandMapper.toPostCreateCommand(request, userSession.userId());
         long newPostId = postService.createPost(command);
 
-        PostCreateResponse response = PostCreateResponse.builder()
-                .postId(newPostId)
-                .build();
+        PostCreateResponse response = postResponseMapper.toPostCreateResponse(newPostId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }

--- a/src/main/java/com/nubble/backend/post/controller/PostApiController.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostApiController.java
@@ -5,6 +5,7 @@ import com.nubble.backend.interceptor.session.SessionRequired;
 import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
 import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
 import com.nubble.backend.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,7 @@ public class PostApiController {
                 .body(response);
     }
 
+    // todo patch /{postId} 로 수정하기
     @PatchMapping(
             path = "/{postId}/publish",
             consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -51,9 +53,10 @@ public class PostApiController {
             @PathVariable Long postId,
             UserSession userSession
     ) {
+        PostPublishCommand command = postCommandMapper.toPostPublishCommand(request, postId, userSession.userId());
+        postService.publishPost(command);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }
-
-
 }

--- a/src/main/java/com/nubble/backend/post/controller/PostApiController.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostApiController.java
@@ -1,0 +1,33 @@
+package com.nubble.backend.post.controller;
+
+import com.nubble.backend.config.resolver.UserSession;
+import com.nubble.backend.interceptor.session.SessionRequired;
+import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
+import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+@Controller
+public class PostApiController {
+
+    @SessionRequired
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PostCreateResponse> createPost(
+            @Valid @RequestBody PostCreateRequest request, UserSession userSession) {
+        PostCreateResponse response = PostCreateResponse.builder().build();
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/src/main/java/com/nubble/backend/post/controller/PostApiController.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostApiController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +32,8 @@ public class PostApiController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @SessionRequired
     public ResponseEntity<PostCreateResponse> createPost(
-            @Valid @RequestBody PostCreateRequest request, UserSession userSession) {
+            @Valid @RequestBody PostCreateRequest request, UserSession userSession
+    ) {
         PostCreateCommand command = postCommandMapper.toPostCreateCommand(request, userSession.userId());
         long newPostId = postService.createPost(command);
 
@@ -38,4 +41,19 @@ public class PostApiController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }
+
+    @PatchMapping(
+            path = "/{postId}/publish",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @SessionRequired
+    public ResponseEntity<Void> publishPost(
+            @Valid @RequestBody PostRequest.PostPublishRequest request,
+            @PathVariable Long postId,
+            UserSession userSession
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/nubble/backend/post/controller/PostCommandMapper.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostCommandMapper.java
@@ -1,7 +1,9 @@
 package com.nubble.backend.post.controller;
 
 import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
+import com.nubble.backend.post.controller.PostRequest.PostPublishRequest;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -14,4 +16,6 @@ import org.mapstruct.ReportingPolicy;
 public interface PostCommandMapper {
 
     PostCreateCommand toPostCreateCommand(PostCreateRequest request, long userId);
+
+    PostPublishCommand toPostPublishCommand(PostPublishRequest request, Long postId, long userId);
 }

--- a/src/main/java/com/nubble/backend/post/controller/PostCommandMapper.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostCommandMapper.java
@@ -1,0 +1,17 @@
+package com.nubble.backend.post.controller;
+
+import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
+import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface PostCommandMapper {
+
+    PostCreateCommand toPostCreateCommand(PostCreateRequest request, long userId);
+}

--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -13,4 +13,12 @@ public class PostRequest {
             String content) {
 
     }
+
+    @Builder
+    public record PostPublishRequest(
+            String thumbnailUrl,
+            String description
+    ) {
+
+    }
 }

--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -1,0 +1,16 @@
+package com.nubble.backend.post.controller;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostRequest {
+
+    @Builder
+    public record PostCreateRequest(
+            String title,
+            String content) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/post/controller/PostResponse.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostResponse.java
@@ -1,0 +1,15 @@
+package com.nubble.backend.post.controller;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostResponse {
+
+    @Builder
+    public record PostCreateResponse(
+            long postId
+    ) {
+    }
+}

--- a/src/main/java/com/nubble/backend/post/controller/PostResponseMapper.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostResponseMapper.java
@@ -1,0 +1,16 @@
+package com.nubble.backend.post.controller;
+
+import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface PostResponseMapper {
+
+    PostCreateResponse toPostCreateResponse(Long postId);
+}

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -11,10 +11,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Post {
 
@@ -33,7 +36,7 @@ public class Post {
     @JoinColumn(name = "user_id", nullable = false, updatable = false)
     private User user;
 
-    private String thumbnail;
+    private String thumbnailUrl;
 
     private String description;
 
@@ -41,11 +44,37 @@ public class Post {
     private PostStatus status;
 
     @Builder
-
     public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;
         this.user = user;
         status = PostStatus.DRAFT;
+    }
+
+    public void publish() {
+        if (status == PostStatus.PUBLISHED) {
+            throw new RuntimeException("이미 게시된 상태입니다.");
+        }
+        status = PostStatus.PUBLISHED;
+    }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        if (thumbnailUrl == null) {
+            throw new RuntimeException("썸네일 값은 필수입니다.");
+        }
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void updateDescription(String description) {
+        if (description == null) {
+            throw new RuntimeException("게시글 설명은 필수입니다.");
+        }
+        this.description = description;
+    }
+
+    public void validateOwner(Long userId) {
+        if (!user.getId().equals(userId)) {
+            throw new RuntimeException("게시글의 주인이 아닙니다.");
+        }
     }
 }

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -1,0 +1,24 @@
+package com.nubble.backend.post.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Post {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String thumbnail;
+    private String description;
+
+    private PostStatus status;
+
+    @Builder
+    public Post(String title, String content, String thumbnail, String description) {
+        this.title = title;
+        this.content = content;
+        this.thumbnail = thumbnail;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -1,24 +1,41 @@
 package com.nubble.backend.post.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 
+@Entity
 @Getter
 public class Post {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
     private Long id;
+
+    @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false)
     private String content;
+
     private String thumbnail;
+
     private String description;
 
+    @Enumerated(value = EnumType.STRING)
     private PostStatus status;
 
     @Builder
-    public Post(String title, String content, String thumbnail, String description) {
+    public Post(String title, String content) {
         this.title = title;
         this.content = content;
-        this.thumbnail = thumbnail;
-        this.description = description;
+        this.status = PostStatus.DRAFT;
     }
 }

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -1,12 +1,16 @@
 package com.nubble.backend.post.domain;
 
+import com.nubble.backend.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -25,6 +29,10 @@ public class Post {
     @Column(nullable = false)
     private String content;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    private User user;
+
     private String thumbnail;
 
     private String description;
@@ -33,9 +41,11 @@ public class Post {
     private PostStatus status;
 
     @Builder
-    public Post(String title, String content) {
+
+    public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;
-        this.status = PostStatus.DRAFT;
+        this.user = user;
+        status = PostStatus.DRAFT;
     }
 }

--- a/src/main/java/com/nubble/backend/post/domain/PostStatus.java
+++ b/src/main/java/com/nubble/backend/post/domain/PostStatus.java
@@ -1,0 +1,6 @@
+package com.nubble.backend.post.domain;
+
+public enum PostStatus {
+    DRAFT,
+    PUBLISHED
+}

--- a/src/main/java/com/nubble/backend/post/service/PostCommand.java
+++ b/src/main/java/com/nubble/backend/post/service/PostCommand.java
@@ -15,4 +15,14 @@ public class PostCommand {
     ) {
 
     }
+
+    @Builder
+    public record PostPublishCommand(
+            long userId,
+            long postId,
+            String thumbnailUrl,
+            String description
+    ) {
+
+    }
 }

--- a/src/main/java/com/nubble/backend/post/service/PostCommand.java
+++ b/src/main/java/com/nubble/backend/post/service/PostCommand.java
@@ -1,0 +1,17 @@
+package com.nubble.backend.post.service;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostCommand {
+
+    @Builder
+    public record PostCreateCommand(
+            String title,
+            String content
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/post/service/PostCommand.java
+++ b/src/main/java/com/nubble/backend/post/service/PostCommand.java
@@ -10,7 +10,8 @@ public class PostCommand {
     @Builder
     public record PostCreateCommand(
             String title,
-            String content
+            String content,
+            long userId
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/service/PostInfo.java
+++ b/src/main/java/com/nubble/backend/post/service/PostInfo.java
@@ -1,0 +1,15 @@
+package com.nubble.backend.post.service;
+
+import lombok.Builder;
+
+@Builder
+public record PostInfo(
+        long postId,
+        String title,
+        String content,
+        long userId,
+        String thumbnailUrl,
+        String description,
+        String postStatus) {
+
+}

--- a/src/main/java/com/nubble/backend/post/service/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/service/PostRepository.java
@@ -1,0 +1,8 @@
+package com.nubble.backend.post.service;
+
+import com.nubble.backend.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.nubble.backend.post.service;
 
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,26 @@ public class PostService {
 
         return postRepository.save(newPost)
                 .getId();
+    }
+
+    @Transactional
+    public PostInfo publishPost(PostPublishCommand command) {
+        Post post = postRepository.findById(command.postId())
+                .orElseThrow(() -> new RuntimeException("게시글이 존재하지 않습니다."));
+        post.validateOwner(command.userId());
+
+        post.publish();
+        post.updateThumbnailUrl(command.thumbnailUrl());
+        post.updateDescription(command.description());
+
+        return PostInfo.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .userId(post.getUser().getId())
+                .thumbnailUrl(post.getThumbnailUrl())
+                .description(post.getDescription())
+                .postStatus(post.getStatus().name())
+                .build();
     }
 }

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -1,0 +1,12 @@
+package com.nubble.backend.post.service;
+
+import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostService {
+
+    public long createPost(PostCreateCommand command) {
+        return 1L;
+    }
+}

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -2,6 +2,8 @@ package com.nubble.backend.post.service;
 
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import com.nubble.backend.user.domain.User;
+import com.nubble.backend.user.service.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,12 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public long createPost(PostCreateCommand command) {
+        User user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+
         Post newPost = Post.builder()
                 .title(command.title())
                 .content(command.content())
+                .user(user)
                 .build();
 
         return postRepository.save(newPost)

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -31,6 +31,7 @@ public class PostService {
                 .getId();
     }
 
+    // todo publishPost -> updatePost로 변경, 모든 변수들을 변경할 수 있도록 수정, PostValidationHandler 객체를 만들어 검증 수행
     @Transactional
     public PostInfo publishPost(PostPublishCommand command) {
         Post post = postRepository.findById(command.postId())

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -1,12 +1,25 @@
 package com.nubble.backend.post.service;
 
+import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class PostService {
 
+    private final PostRepository postRepository;
+
+    @Transactional
     public long createPost(PostCreateCommand command) {
-        return 1L;
+        Post newPost = Post.builder()
+                .title(command.title())
+                .content(command.content())
+                .build();
+
+        return postRepository.save(newPost)
+                .getId();
     }
 }

--- a/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
@@ -1,0 +1,77 @@
+package com.nubble.backend.post.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.fixture.UserFixture;
+import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
+import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
+import com.nubble.backend.session.domain.Session;
+import com.nubble.backend.session.service.SessionRepository;
+import com.nubble.backend.user.domain.User;
+import com.nubble.backend.user.service.UserRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @DisplayName("로그인된 유저가 게시글을 작성합니다.")
+    @Test
+    void createPost_success() throws Exception {
+        // given
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+        Session session = Session.builder()
+                .user(user)
+                .accessId(UUID.randomUUID().toString())
+                .expireAt(LocalDateTime.now().plusDays(1))
+                .build();
+        sessionRepository.save(session);
+
+        PostCreateRequest request = PostCreateRequest.builder()
+                .title("제목입니다.")
+                .content("내용입니다")
+                .build();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MockHttpServletRequestBuilder requestBuilder = post("/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("SESSION-ID", session.getAccessId())
+                .content(requestJson);
+
+        PostCreateResponse response = PostCreateResponse.builder()
+                .postId(1L)
+                .build();
+        String responseJson = objectMapper.writeValueAsString(response);
+
+        // when & then
+        mockMvc.perform(requestBuilder)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(responseJson))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
@@ -48,6 +48,9 @@ class PostApiControllerTest {
     @Autowired
     private PostCommandMapper postCommandMapper;
 
+    @Autowired
+    private PostResponseMapper postResponseMapper;
+
     @MockBean
     private PostService postService;
 
@@ -80,9 +83,7 @@ class PostApiControllerTest {
                 .header("SESSION-ID", session.getAccessId())
                 .content(requestJson);
 
-        PostCreateResponse response = PostCreateResponse.builder()
-                .postId(newPostId)
-                .build();
+        PostCreateResponse response = postResponseMapper.toPostCreateResponse(newPostId);
         String responseJson = objectMapper.writeValueAsString(response);
 
         // when & then

--- a/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
@@ -1,13 +1,16 @@
 package com.nubble.backend.post.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.post.controller.PostRequest.PostCreateRequest;
+import com.nubble.backend.post.controller.PostRequest.PostPublishRequest;
 import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostService;
@@ -88,8 +91,43 @@ class PostApiControllerTest {
 
         // when & then
         mockMvc.perform(requestBuilder)
+                .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(responseJson))
                 .andDo(print());
     }
+
+    @DisplayName("")
+    @Test
+    void publishPost() throws Exception {
+        // given
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+        Session session = Session.builder()
+                .user(user)
+                .accessId(UUID.randomUUID().toString())
+                .expireAt(LocalDateTime.now().plusDays(1))
+                .build();
+        sessionRepository.save(session);
+
+        PostPublishRequest request = PostPublishRequest.builder()
+                .thumbnailUrl("https://example.com/thumbnail.jpg")
+                .description("설명입니다.")
+                .build();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        Long postId = 1L;
+        MockHttpServletRequestBuilder requestBuilder = patch("/posts/{postId}/publish", postId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("SESSION-ID", session.getAccessId())
+                .content(requestJson);
+
+        // when & then
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(content().string(""))
+                .andDo(print());
+    }
+
+
 }

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -1,6 +1,11 @@
 package com.nubble.backend.post.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +18,9 @@ class PostServiceTest {
 
     @Autowired
     private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
 
     @DisplayName("게시글을 생성한다.")
     @Test
@@ -27,6 +35,14 @@ class PostServiceTest {
         long newPostId = postService.createPost(command);
 
         // then
-        // todo 게시글 저장소에 command 내용으로 작성된 게시글이 저장되어 있어야 한다.
+        Optional<Post> postOptional = postRepository.findById(newPostId);
+
+        assertThat(postOptional).isPresent();
+        assertThat(postOptional.get().getId()).isEqualTo(newPostId);
+        assertThat(postOptional.get().getTitle()).isEqualTo(command.title());
+        assertThat(postOptional.get().getContent()).isEqualTo(command.content());
+        assertThat(postOptional.get().getStatus()).isEqualTo(PostStatus.DRAFT);
+        assertThat(postOptional.get().getThumbnail()).isNull();
+        assertThat(postOptional.get().getDescription()).isNull();
     }
 }

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -1,0 +1,32 @@
+package com.nubble.backend.post.service;
+
+import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+
+    @Autowired
+    private PostService postService;
+
+    @DisplayName("게시글을 생성한다.")
+    @Test
+    void createPost_success() {
+        // given
+        PostCreateCommand command = PostCreateCommand.builder()
+                .title("제목입니다.")
+                .content("내용입니다.")
+                .build();
+
+        // when
+        long newPostId = postService.createPost(command);
+
+        // then
+        // todo 게시글 저장소에 command 내용으로 작성된 게시글이 저장되어 있어야 한다.
+    }
+}

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -2,9 +2,12 @@ package com.nubble.backend.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
+import com.nubble.backend.user.domain.User;
+import com.nubble.backend.user.service.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,13 +25,20 @@ class PostServiceTest {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @DisplayName("게시글을 생성한다.")
     @Test
     void createPost_success() {
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+
         // given
         PostCreateCommand command = PostCreateCommand.builder()
                 .title("제목입니다.")
                 .content("내용입니다.")
+                .userId(user.getId())
                 .build();
 
         // when
@@ -41,6 +51,7 @@ class PostServiceTest {
         assertThat(postOptional.get().getId()).isEqualTo(newPostId);
         assertThat(postOptional.get().getTitle()).isEqualTo(command.title());
         assertThat(postOptional.get().getContent()).isEqualTo(command.content());
+        assertThat(postOptional.get().getUser().getId()).isEqualTo(user.getId());
         assertThat(postOptional.get().getStatus()).isEqualTo(PostStatus.DRAFT);
         assertThat(postOptional.get().getThumbnail()).isNull();
         assertThat(postOptional.get().getDescription()).isNull();


### PR DESCRIPTION
## 문제

게시글 등록 및 게시 기능을 구현하였습니다.
한데, 설계를 잘못하여 범용성이 없이 등록과 게시에만 사용되는 엔드포인트입니다.
추후 게시 api -> 게시 + 수정 api로 합칠 예정입니다.(`Patch posts/{postId}/publish` -> `Patch posts/{postId}`)

# 게시글 등록, POST /posts 

## 요청

```http
POST /posts HTTP/1.1
Host: example.com
Content-Type: application/json
Accept: application/json
SESSION-ID: 11660e50-6df9-4549-a033-a989e52de9d1

{
    "title": "새로운 게시물 제목",
    "content": "이것은 게시물의 내용입니다."
}
```

## 응답

```http
HTTP/1.1 201 Created
Content-Type: application/json

{
    "postId": 12345
}
```

# 게시글 출간, Patch posts/{postId}/publish

## 요청

```http
PATCH /posts/12345/publish HTTP/1.1
Host: example.com
Content-Type: application/json
SESSION-ID: 11660e50-6df9-4549-a033-a989e52de9d1

{
    "thumbnailUrl": "http://example.com/image.jpg",
    "description": "게시물 설명입니다."
}
```

## 응답

```http
HTTP/1.1 200 OK
```