### PR TITLE
feat: 카테고리를 조회하는 엔드포인트 구현

### DIFF
--- a/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
@@ -1,0 +1,30 @@
+package com.nubble.backend.category.controller;
+
+import com.nubble.backend.category.service.CategoryInfo;
+import com.nubble.backend.category.service.CategoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryApiController {
+
+    private final CategoryService categoryService;
+    private final CategoryResponseMapper categoryResponseMapper;
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CategoryResponse.CategoriesDto> findCategories() {
+        List<CategoryInfo> infos = categoryService.findRootCategory();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(categoryResponseMapper.toCategoryFindResponses(infos));
+    }
+
+}

--- a/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
@@ -21,7 +21,7 @@ public class CategoryApiController {
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CategoryResponse.CategoriesDto> findCategories() {
-        List<CategoryInfo> infos = categoryService.findRootCategory();
+        List<CategoryInfo.CategoryDto> infos = categoryService.findRootCategory();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(categoryResponseMapper.toCategoryFindResponses(infos));

--- a/src/main/java/com/nubble/backend/category/controller/CategoryResponse.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryResponse.java
@@ -1,0 +1,25 @@
+package com.nubble.backend.category.controller;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryResponse {
+
+    @Builder
+    public record CategoryDto(
+            long categoryId,
+            String categoryName
+    ) {
+
+    }
+
+    @Builder
+    public record CategoriesDto(
+            List<CategoryDto> categories
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
@@ -1,0 +1,30 @@
+package com.nubble.backend.category.controller;
+
+import com.nubble.backend.category.service.CategoryInfo;
+import java.util.List;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface CategoryResponseMapper {
+
+    @Mapping(target = "categoryId", source = "id")
+    @Mapping(target = "categoryName", source = "name")
+    CategoryResponse.CategoryDto toCategoryFindResponse(CategoryInfo info);
+
+    default CategoryResponse.CategoriesDto toCategoryFindResponses(List<CategoryInfo> infos) {
+        List<CategoryResponse.CategoryDto> list = infos.stream()
+                .map(this::toCategoryFindResponse)
+                .toList();
+
+        return CategoryResponse.CategoriesDto.builder()
+                .categories(list)
+                .build();
+    }
+}

--- a/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
@@ -16,15 +16,15 @@ public interface CategoryResponseMapper {
 
     @Mapping(target = "categoryId", source = "id")
     @Mapping(target = "categoryName", source = "name")
-    CategoryResponse.CategoryDto toCategoryFindResponse(CategoryInfo info);
+    CategoryResponse.CategoryDto toCategoryFindResponse(CategoryInfo.CategoryDto info);
 
-    default CategoryResponse.CategoriesDto toCategoryFindResponses(List<CategoryInfo> infos) {
-        List<CategoryResponse.CategoryDto> list = infos.stream()
+    default CategoryResponse.CategoriesDto toCategoryFindResponses(List<CategoryInfo.CategoryDto> infos) {
+        List<CategoryResponse.CategoryDto> categories = infos.stream()
                 .map(this::toCategoryFindResponse)
                 .toList();
 
         return CategoryResponse.CategoriesDto.builder()
-                .categories(list)
+                .categories(categories)
                 .build();
     }
 }

--- a/src/main/java/com/nubble/backend/category/domain/Category.java
+++ b/src/main/java/com/nubble/backend/category/domain/Category.java
@@ -1,0 +1,41 @@
+package com.nubble.backend.category.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id")
+    private Category parentCategory;
+
+    @Builder
+    protected Category(String name, Category parentCategory) {
+        this.name = name;
+        this.parentCategory = parentCategory;
+    }
+}

--- a/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
@@ -1,5 +1,8 @@
 package com.nubble.backend.category.service;
 
+import lombok.Builder;
+
+@Builder
 public record CategoryInfo(
         long id,
         String name

--- a/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
@@ -1,0 +1,8 @@
+package com.nubble.backend.category.service;
+
+public record CategoryInfo(
+        long id,
+        String name
+) {
+
+}

--- a/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryInfo.java
@@ -1,11 +1,17 @@
 package com.nubble.backend.category.service;
 
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
-@Builder
-public record CategoryInfo(
-        long id,
-        String name
-) {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryInfo {
+
+    @Builder
+    public record CategoryDto(
+            long id,
+            String name
+    ) {
+    }
 
 }

--- a/src/main/java/com/nubble/backend/category/service/CategoryInfoMapper.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryInfoMapper.java
@@ -1,0 +1,16 @@
+package com.nubble.backend.category.service;
+
+import com.nubble.backend.category.domain.Category;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface CategoryInfoMapper {
+
+    CategoryInfo toCategoryInfo(Category c);
+}

--- a/src/main/java/com/nubble/backend/category/service/CategoryInfoMapper.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryInfoMapper.java
@@ -12,5 +12,5 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface CategoryInfoMapper {
 
-    CategoryInfo toCategoryInfo(Category c);
+    CategoryInfo.CategoryDto toCategoryInfo(Category c);
 }

--- a/src/main/java/com/nubble/backend/category/service/CategoryRepository.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.nubble.backend.category.service;
+
+import com.nubble.backend.category.domain.Category;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findAllByParentCategoryIsNull();
+}

--- a/src/main/java/com/nubble/backend/category/service/CategoryService.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryService.java
@@ -1,0 +1,19 @@
+package com.nubble.backend.category.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryInfoMapper categoryInfoMapper;
+
+    public List<CategoryInfo> findRootCategory() {
+        return categoryRepository.findAllByParentCategoryIsNull().stream()
+                .map(categoryInfoMapper::toCategoryInfo)
+                .toList();
+    }
+}

--- a/src/main/java/com/nubble/backend/category/service/CategoryService.java
+++ b/src/main/java/com/nubble/backend/category/service/CategoryService.java
@@ -11,7 +11,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryInfoMapper categoryInfoMapper;
 
-    public List<CategoryInfo> findRootCategory() {
+    public List<CategoryInfo.CategoryDto> findRootCategory() {
         return categoryRepository.findAllByParentCategoryIsNull().stream()
                 .map(categoryInfoMapper::toCategoryInfo)
                 .toList();

--- a/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
@@ -41,16 +41,16 @@ class CategoryApiControllerTest {
     @DisplayName("모든 루트 카테고리를 반환한다.")
     @Test
     void findCategories_success() throws Exception {
-        // 저장되어 있는 루트 카테고리들
-        CategoryInfo rootCategory1 = CategoryInfo.builder()
+        // 저장되어 있는 루트 카테고리들의 정보
+        CategoryInfo.CategoryDto rootCategory1 = CategoryInfo.CategoryDto.builder()
                 .id(1L)
                 .name("코딩테스트")
                 .build();
-        CategoryInfo rootCategory2 = CategoryInfo.builder()
+        CategoryInfo.CategoryDto rootCategory2 = CategoryInfo.CategoryDto.builder()
                 .id(1L)
                 .name("스터디")
                 .build();
-        List<CategoryInfo> infos = List.of(rootCategory1, rootCategory2);
+        List<CategoryInfo.CategoryDto> infos = List.of(rootCategory1, rootCategory2);
 
         // 컨트롤러에 요청이 들어오면 서비스를 통해 저장된 루트 카테고리들을 가져온다.
         given(categoryService.findRootCategory())

--- a/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
@@ -1,0 +1,91 @@
+package com.nubble.backend.category.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.category.controller.CategoryResponse.CategoriesDto;
+import com.nubble.backend.category.service.CategoryInfo;
+import com.nubble.backend.category.service.CategoryService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class CategoryApiControllerTest {
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @Autowired
+    private CategoryResponseMapper categoryResponseMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("모든 루트 카테고리를 반환한다.")
+    @Test
+    void findCategories_success() throws Exception {
+        // 저장되어 있는 루트 카테고리들
+        CategoryInfo rootCategory1 = CategoryInfo.builder()
+                .id(1L)
+                .name("코딩테스트")
+                .build();
+        CategoryInfo rootCategory2 = CategoryInfo.builder()
+                .id(1L)
+                .name("스터디")
+                .build();
+        List<CategoryInfo> infos = List.of(rootCategory1, rootCategory2);
+
+        // 컨트롤러에 요청이 들어오면 서비스를 통해 저장된 루트 카테고리들을 가져온다.
+        given(categoryService.findRootCategory())
+                .willReturn(infos);
+
+        /*
+          HTTP Request:
+          GET /categories HTTP/1.1
+          Host: localhost:8080
+          Accept: application/json
+         */
+        MockHttpServletRequestBuilder requestBuilder = get("/categories");
+
+        /*
+           HTTP Response:
+          HTTP/1.1 200 OK
+          Content-Type: application/json
+
+          {
+            "categories": [
+              {
+                "id": 1,
+                "name": "코딩테스트"
+              },
+              {
+                "id": 2,
+                "name": "스터디"
+              }
+            ]
+          }
+         */
+        CategoriesDto responses = categoryResponseMapper.toCategoryFindResponses(infos);
+        mockMvc.perform(requestBuilder)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(objectMapper.writeValueAsString(responses)))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/nubble/backend/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/nubble/backend/category/service/CategoryServiceTest.java
@@ -1,0 +1,44 @@
+package com.nubble.backend.category.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.category.domain.Category;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CategoryServiceTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Test
+    void findRootCategory_shouldReturnAllRootCategory() {
+        // 루트 카테고리를 한다.
+        Category root = Category.builder()
+                .name("root")
+                .build();
+        categoryRepository.save(root);
+
+        // 루트 카테고리의 자식 카테고리를 저장한다.
+        Category child = Category.builder()
+                .name("child")
+                .parentCategory(root)
+                .build();
+        categoryRepository.save(child);
+
+        // 루트 카테고리를 가져온다.
+        List<CategoryInfo> categoryInfos = categoryService.findRootCategory();
+
+        // 루트 카테고리만 가져오므로 총 1개를 가져와야 한다.
+        assertThat(categoryInfos).hasSize(1);
+        assertThat(categoryInfos.getFirst().name()).isEqualTo(root.getName());
+    }
+}

--- a/src/test/java/com/nubble/backend/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/nubble/backend/category/service/CategoryServiceTest.java
@@ -35,7 +35,7 @@ class CategoryServiceTest {
         categoryRepository.save(child);
 
         // 루트 카테고리를 가져온다.
-        List<CategoryInfo> categoryInfos = categoryService.findRootCategory();
+        List<CategoryInfo.CategoryDto> categoryInfos = categoryService.findRootCategory();
 
         // 루트 카테고리만 가져오므로 총 1개를 가져와야 한다.
         assertThat(categoryInfos).hasSize(1);


### PR DESCRIPTION
## 요청

```http
GET /categories HTTP/1.1
Host: localhost:8080
Accept: application/json
```

## 응답
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
  "categories": [
    {
      "id": 1,
      "name": "코딩테스트"
    },
    {
      "id": 2,
      "name": "스터디"
    }
  ]
}
```
