### PR TITLE
feat: 카테고리 id와 매핑된 게시판 조회 엔드포인트 구현

### DIFF
--- a/src/main/java/com/nubble/backend/board/domain/Board.java
+++ b/src/main/java/com/nubble/backend/board/domain/Board.java
@@ -27,7 +27,7 @@ public class Board {
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     @Builder

--- a/src/main/java/com/nubble/backend/board/domain/Board.java
+++ b/src/main/java/com/nubble/backend/board/domain/Board.java
@@ -1,16 +1,33 @@
 package com.nubble.backend.board.domain;
 
 import com.nubble.backend.category.domain.Category;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "boards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Board {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
     private Category category;
 
     @Builder

--- a/src/main/java/com/nubble/backend/board/domain/Board.java
+++ b/src/main/java/com/nubble/backend/board/domain/Board.java
@@ -1,0 +1,21 @@
+package com.nubble.backend.board.domain;
+
+import com.nubble.backend.category.domain.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Board {
+
+    private Long id;
+
+    private String name;
+
+    private Category category;
+
+    @Builder
+    protected Board(String name, Category category) {
+        this.name = name;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/nubble/backend/board/service/BoardInfo.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardInfo.java
@@ -1,0 +1,17 @@
+package com.nubble.backend.board.service;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardInfo {
+
+    @Builder
+    public record BoardDto(
+            long boardId,
+            String boardName,
+            long categoryId
+    ) {
+    }
+}

--- a/src/main/java/com/nubble/backend/board/service/BoardInfo.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardInfo.java
@@ -9,8 +9,8 @@ public class BoardInfo {
 
     @Builder
     public record BoardDto(
-            long boardId,
-            String boardName,
+            long id,
+            String name,
             long categoryId
     ) {
     }

--- a/src/main/java/com/nubble/backend/board/service/BoardInfoMapper.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardInfoMapper.java
@@ -13,8 +13,6 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface BoardInfoMapper {
 
-    @Mapping(target = "boardId", source = "id")
-    @Mapping(target = "boardName", source = "name")
     @Mapping(target = "categoryId", source = "category.id")
     BoardInfo.BoardDto toBoardDto(Board board);
 }

--- a/src/main/java/com/nubble/backend/board/service/BoardInfoMapper.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardInfoMapper.java
@@ -1,0 +1,20 @@
+package com.nubble.backend.board.service;
+
+import com.nubble.backend.board.domain.Board;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface BoardInfoMapper {
+
+    @Mapping(target = "boardId", source = "id")
+    @Mapping(target = "boardName", source = "name")
+    @Mapping(target = "categoryId", source = "category.id")
+    BoardInfo.BoardDto toBoardDto(Board board);
+}

--- a/src/main/java/com/nubble/backend/board/service/BoardRepository.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardRepository.java
@@ -1,0 +1,10 @@
+package com.nubble.backend.board.service;
+
+import com.nubble.backend.board.domain.Board;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    List<Board> findAllByCategoryId(long categoryId);
+}

--- a/src/main/java/com/nubble/backend/board/service/BoardService.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardService.java
@@ -10,22 +10,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BoardService {
 
-    public final BoardRepository boardRepository;
+    private final BoardRepository boardRepository;
+    private final BoardInfoMapper boardInfoMapper;
 
     @Transactional(readOnly = true)
     public List<BoardInfo.BoardDto> findBoardByCategoryId(long categoryId) {
         List<Board> boards = boardRepository.findAllByCategoryId(categoryId);
 
         return boards.stream()
-                .map(this::mapToBoardDto)
+                .map(boardInfoMapper::toBoardDto)
                 .toList();
-    }
-
-    private BoardInfo.BoardDto mapToBoardDto(Board board) {
-        return BoardInfo.BoardDto.builder()
-                .boardId(board.getId())
-                .boardName(board.getName())
-                .categoryId(board.getCategory().getId())
-                .build();
     }
 }

--- a/src/main/java/com/nubble/backend/board/service/BoardService.java
+++ b/src/main/java/com/nubble/backend/board/service/BoardService.java
@@ -1,0 +1,31 @@
+package com.nubble.backend.board.service;
+
+import com.nubble.backend.board.domain.Board;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    public final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public List<BoardInfo.BoardDto> findBoardByCategoryId(long categoryId) {
+        List<Board> boards = boardRepository.findAllByCategoryId(categoryId);
+
+        return boards.stream()
+                .map(this::mapToBoardDto)
+                .toList();
+    }
+
+    private BoardInfo.BoardDto mapToBoardDto(Board board) {
+        return BoardInfo.BoardDto.builder()
+                .boardId(board.getId())
+                .boardName(board.getName())
+                .categoryId(board.getCategory().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryApiController.java
@@ -1,5 +1,7 @@
 package com.nubble.backend.category.controller;
 
+import com.nubble.backend.board.service.BoardInfo;
+import com.nubble.backend.board.service.BoardService;
 import com.nubble.backend.category.service.CategoryInfo;
 import com.nubble.backend.category.service.CategoryService;
 import java.util.List;
@@ -8,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +21,7 @@ public class CategoryApiController {
 
     private final CategoryService categoryService;
     private final CategoryResponseMapper categoryResponseMapper;
+    private final BoardService boardService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CategoryResponse.CategoriesDto> findCategories() {
@@ -27,4 +31,14 @@ public class CategoryApiController {
                 .body(categoryResponseMapper.toCategoryFindResponses(infos));
     }
 
+    @GetMapping(
+            path = "/{categoryId}/boards",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<CategoryResponse.BoardsDto> findBoardsByCategoryId(@PathVariable Long categoryId) {
+        List<BoardInfo.BoardDto> infos = boardService.findBoardByCategoryId(categoryId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(categoryResponseMapper.toBoardsDto(infos));
+    }
 }

--- a/src/main/java/com/nubble/backend/category/controller/CategoryResponse.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryResponse.java
@@ -22,4 +22,17 @@ public class CategoryResponse {
     ) {
 
     }
+
+    @Builder
+    public record BoardDto(
+            long id,
+            String name
+    ) {
+    }
+
+    @Builder
+    public record BoardsDto(
+            List<BoardDto> boards
+    ) {
+    }
 }

--- a/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
+++ b/src/main/java/com/nubble/backend/category/controller/CategoryResponseMapper.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.category.controller;
 
+import com.nubble.backend.board.service.BoardInfo;
 import com.nubble.backend.category.service.CategoryInfo;
 import java.util.List;
 import org.mapstruct.InjectionStrategy;
@@ -25,6 +26,18 @@ public interface CategoryResponseMapper {
 
         return CategoryResponse.CategoriesDto.builder()
                 .categories(categories)
+                .build();
+    }
+
+    CategoryResponse.BoardDto toBoardDto(BoardInfo.BoardDto info);
+
+    default CategoryResponse.BoardsDto toBoardsDto(List<BoardInfo.BoardDto> infos) {
+        List<CategoryResponse.BoardDto> list = infos.stream()
+                .map(this::toBoardDto)
+                .toList();
+
+        return CategoryResponse.BoardsDto.builder()
+                .boards(list)
                 .build();
     }
 }

--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -10,8 +10,9 @@ public class PostRequest {
     @Builder
     public record PostCreateRequest(
             String title,
-            String content) {
-
+            String content,
+            Long boardId) {
+        
     }
 
     @Builder

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.post.domain;
 
+import com.nubble.backend.board.domain.Board;
 import com.nubble.backend.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -43,12 +44,17 @@ public class Post {
     @Enumerated(value = EnumType.STRING)
     private PostStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
     @Builder
-    public Post(String title, String content, User user) {
+    public Post(String title, String content, User user, Board board) {
         this.title = title;
         this.content = content;
         this.user = user;
         status = PostStatus.DRAFT;
+        this.board = board;
     }
 
     public void publish() {

--- a/src/main/java/com/nubble/backend/post/service/PostCommand.java
+++ b/src/main/java/com/nubble/backend/post/service/PostCommand.java
@@ -11,7 +11,8 @@ public class PostCommand {
     public record PostCreateCommand(
             String title,
             String content,
-            long userId
+            long userId,
+            long boardId
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.nubble.backend.post.service;
 
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.board.service.BoardRepository;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
@@ -15,16 +17,20 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
 
     @Transactional
     public long createPost(PostCreateCommand command) {
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+        Board board = boardRepository.findById(command.boardId())
+                .orElseThrow(() -> new RuntimeException("게시판이 존재하지 않습니다."));
 
         Post newPost = Post.builder()
                 .title(command.title())
                 .content(command.content())
                 .user(user)
+                .board(board)
                 .build();
 
         return postRepository.save(newPost)

--- a/src/test/java/com/nubble/backend/board/service/BoardServiceTest.java
+++ b/src/test/java/com/nubble/backend/board/service/BoardServiceTest.java
@@ -1,0 +1,64 @@
+package com.nubble.backend.board.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.board.service.BoardInfo.BoardDto;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class BoardServiceTest {
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DisplayName("카테고리 아이디와 매핑되는 게시판을 반환한다.")
+    @Test
+    void findBoardByCategoryId_shouldReturnBoardDtoMappedCategoryId() {
+        // 카테고리를 생성한다.
+        Category mappedCategory = Category.builder()
+                .name("매핑된 카테고리")
+                .build();
+        Category unmappedCategory = Category.builder()
+                .name("다른 카테고리")
+                .build();
+        categoryRepository.saveAll(List.of(mappedCategory, unmappedCategory));
+
+        // 카테고리와 매핑된 게시판을 생성한다.
+        // 다른 카테고리와 매핑되는 게시판을 생성한다.
+        Board mappedBoard1 = Board.builder()
+                .name("반환되는 게시판1")
+                .category(mappedCategory)
+                .build();
+        Board mappedBoard2 = Board.builder()
+                .name("반환되는 게시판2")
+                .category(mappedCategory)
+                .build();
+        Board unmappedBoard = Board.builder()
+                .name("반환되지 않는 게시판")
+                .category(unmappedCategory)
+                .build();
+        boardRepository.saveAll(List.of(mappedBoard1, mappedBoard2, unmappedBoard));
+
+        // 카테고리 아이디를 통해 게시판의 정보를 찾는다.
+        List<BoardDto> result = boardService.findBoardByCategoryId(mappedCategory.getId());
+
+        // 카테고리와 매핑된 게시판이 반환되었는지 검증한다.
+        assertThat(result).hasSize(2)
+                .allMatch(dto -> dto.boardName().startsWith("반환되는 게시판"));
+    }
+}

--- a/src/test/java/com/nubble/backend/board/service/BoardServiceTest.java
+++ b/src/test/java/com/nubble/backend/board/service/BoardServiceTest.java
@@ -59,6 +59,6 @@ class BoardServiceTest {
 
         // 카테고리와 매핑된 게시판이 반환되었는지 검증한다.
         assertThat(result).hasSize(2)
-                .allMatch(dto -> dto.boardName().startsWith("반환되는 게시판"));
+                .allMatch(dto -> dto.name().startsWith("반환되는 게시판"));
     }
 }

--- a/src/test/java/com/nubble/backend/comment/service/CommentFactoryTest.java
+++ b/src/test/java/com/nubble/backend/comment/service/CommentFactoryTest.java
@@ -2,6 +2,10 @@ package com.nubble.backend.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
 import com.nubble.backend.comment.domain.Comment;
 import com.nubble.backend.comment.domain.GuestComment;
 import com.nubble.backend.comment.domain.MemberComment;
@@ -12,6 +16,7 @@ import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.service.PostRepository;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +36,28 @@ class CommentFactoryTest {
     @Autowired
     private PostRepository postRepository;
 
+    private Board board;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @BeforeEach
+    void setup() {
+        Category category = Category.builder()
+                .name("루트 카테고리")
+                .build();
+        categoryRepository.save(category);
+
+        board = Board.builder()
+                .category(category)
+                .name("게시판 이름")
+                .build();
+        boardRepository.save(board);
+    }
+
     @DisplayName("회원 댓글을 생성합니다.")
     @Test
     void generateMemberComment_success() {
@@ -42,6 +69,7 @@ class CommentFactoryTest {
                 .user(user)
                 .title("제목입니다.")
                 .content("게시글 내용입니다.")
+                .board(board)
                 .build();
         postRepository.save(post);
 
@@ -76,6 +104,7 @@ class CommentFactoryTest {
                 .user(user)
                 .title("제목입니다.")
                 .content("게시글 내용입니다.")
+                .board(board)
                 .build();
         postRepository.save(post);
 

--- a/src/test/java/com/nubble/backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/nubble/backend/comment/service/CommentServiceTest.java
@@ -2,6 +2,10 @@ package com.nubble.backend.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
 import com.nubble.backend.comment.domain.GuestComment;
 import com.nubble.backend.comment.domain.MemberComment;
 import com.nubble.backend.comment.service.CommentCommand.CommentCreateCommand;
@@ -14,6 +18,7 @@ import com.nubble.backend.user.service.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +37,31 @@ class CommentServiceTest {
 
     @Autowired
     private PostRepository postRepository;
+
     @Autowired
     private CommentRepository commentRepository;
+
+    private Board board;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @BeforeEach
+    void setup() {
+        Category category = Category.builder()
+                .name("루트 카테고리")
+                .build();
+        categoryRepository.save(category);
+
+        board = Board.builder()
+                .category(category)
+                .name("게시판 이름")
+                .build();
+        boardRepository.save(board);
+    }
 
     @DisplayName("회원 댓글을 생성합니다.")
     @Test
@@ -46,6 +74,7 @@ class CommentServiceTest {
                 .user(user)
                 .title("제목입니다.")
                 .content("게시글 내용입니다.")
+                .board(board)
                 .build();
         postRepository.save(post);
 
@@ -74,6 +103,7 @@ class CommentServiceTest {
                 .user(user)
                 .title("제목입니다.")
                 .content("게시글 내용입니다.")
+                .board(board)
                 .build();
         postRepository.save(post);
 
@@ -109,6 +139,7 @@ class CommentServiceTest {
                 .user(user)
                 .title("제목입니다.")
                 .content("게시글 내용입니다.")
+                .board(board)
                 .build();
         postRepository.save(post);
 

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -2,6 +2,10 @@ package com.nubble.backend.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
@@ -10,6 +14,7 @@ import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +34,28 @@ class PostServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    private Board board;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @BeforeEach
+    void setup() {
+        Category category = Category.builder()
+                .name("루트 카테고리")
+                .build();
+        categoryRepository.save(category);
+
+        board = Board.builder()
+                .category(category)
+                .name("게시판 이름")
+                .build();
+        boardRepository.save(board);
+    }
+
     @DisplayName("게시글을 생성한다.")
     @Test
     void createPost_success() {
@@ -40,6 +67,7 @@ class PostServiceTest {
                 .title("제목입니다.")
                 .content("내용입니다.")
                 .userId(user.getId())
+                .boardId(board.getId())
                 .build();
 
         // when
@@ -69,6 +97,7 @@ class PostServiceTest {
                 .title("제목입니다.")
                 .content("내용입니다.")
                 .userId(user.getId())
+                .boardId(board.getId())
                 .build();
         long postId = postService.createPost(postCreateCommand);
 


### PR DESCRIPTION
## 작업 내용

- 카테고리와 매핑된 게시판들을 조회하는 엔드포인트를 구현
- 게시글(Post) 도메인에 Board 필드 추가
  - 게시판과 매핑된 게시글 조회 기능도 필요하나, Post 리팩토링이 필요하여 멈춤

## 카테고리와 매핑된 게시판들을 조회하는 엔드포인트(/categories/{categoryId})

### 요청
```http
GET /categories/{categoryId}/boards HTTP/1.1
Host: localhost:8080
```

### 응답
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
    "boards": [
        {
            "id": 1,
            "name": "매핑된 게시판1"
        },
        {
            "id": 2,
            "name": "매핑된 게시판2"
        }
    ]
}
```
