### PR TITLE
feat: 게시글 생성시, 상태 선택 가능하도록 수정

### DIFF
--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -22,19 +22,19 @@ public class PostRequest {
 
     @Builder
     public record PostCreateRequest(
-            @NotBlank
-            @Max(value = TITLE_MAX_LENGTH, message = TITLE_MAX_LENGTH_MESSAGE)
+            @NotBlank(message = "게시글 제목은 비어있을 수 없습니다.")
+            @Size(max = TITLE_MAX_LENGTH, message = TITLE_MAX_LENGTH_MESSAGE)
             String title,
 
-            @NotBlank
+            @NotBlank(message = "게시글 내용은 비어있을 수 없습니다.")
             @Size(max = CONTENT_MAX_LENGTH, message = CONTENT_MAX_LENGTH_MESSAGE)
             String content,
 
-            @NotBlank
+            @NotNull(message = "게시판 아이디는 null일 수 없습니다.")
             @Min(value = 1, message = "boardId는 최소 1이상 이어야 합니다.")
             Long boardId,
 
-            @NotNull(message = "게시글 상태는 필수입니다.")
+            @NotNull(message = "게시글 상태는 null일 수 없습니다.")
             PostStatusDto status,
 
             String thumbnailUrl,

--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -1,6 +1,11 @@
 package com.nubble.backend.post.controller;
 
 import com.nubble.backend.post.shared.PostStatusDto;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -8,13 +13,33 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostRequest {
 
+    public static final int TITLE_MAX_LENGTH = 255;
+    public static final int CONTENT_MAX_LENGTH = 255;
+    public static final int DESCRIPTION_MAX_LENGTH = 500;
+    public static final String TITLE_MAX_LENGTH_MESSAGE = "게시글 제목의 길이는 최대 " + TITLE_MAX_LENGTH + "까지 가능합니다.";
+    public static final String CONTENT_MAX_LENGTH_MESSAGE = "게시글 내용의 길이는 최대 " + TITLE_MAX_LENGTH + "까지 가능합니다.";
+    public static final String DESCRIPTION_MAX_LENGTH_MESSAGE = "게시글 요약의 길이는 최대 " + DESCRIPTION_MAX_LENGTH + "까지 가능합니다.";
+
     @Builder
     public record PostCreateRequest(
+            @NotBlank
+            @Max(value = TITLE_MAX_LENGTH, message = TITLE_MAX_LENGTH_MESSAGE)
             String title,
+
+            @NotBlank
+            @Size(max = CONTENT_MAX_LENGTH, message = CONTENT_MAX_LENGTH_MESSAGE)
             String content,
+
+            @NotBlank
+            @Min(value = 1, message = "boardId는 최소 1이상 이어야 합니다.")
             Long boardId,
+
+            @NotNull(message = "게시글 상태는 필수입니다.")
             PostStatusDto status,
+
             String thumbnailUrl,
+
+            @Max(value = DESCRIPTION_MAX_LENGTH, message = DESCRIPTION_MAX_LENGTH_MESSAGE)
             String description) {
 
     }

--- a/src/main/java/com/nubble/backend/post/controller/PostRequest.java
+++ b/src/main/java/com/nubble/backend/post/controller/PostRequest.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.post.controller;
 
+import com.nubble.backend.post.shared.PostStatusDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -11,8 +12,11 @@ public class PostRequest {
     public record PostCreateRequest(
             String title,
             String content,
-            Long boardId) {
-        
+            Long boardId,
+            PostStatusDto status,
+            String thumbnailUrl,
+            String description) {
+
     }
 
     @Builder

--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -49,12 +49,30 @@ public class Post {
     private Board board;
 
     @Builder
-    public Post(String title, String content, User user, Board board) {
+    protected Post(
+            String title,
+            String content,
+            User user,
+            String thumbnailUrl,
+            String description,
+            PostStatus status,
+            Board board) {
         this.title = title;
         this.content = content;
         this.user = user;
-        status = PostStatus.DRAFT;
+        this.thumbnailUrl = thumbnailUrl;
+        this.description = description;
+        this.status = status;
         this.board = board;
+
+        if (this.status == PostStatus.PUBLISHED) {
+            if (thumbnailUrl == null || thumbnailUrl.isEmpty()) {
+                throw new RuntimeException("게시한 상태에서는 썸네일 URL이 필요합니다.");
+            }
+            if (description == null || description.isEmpty()) {
+                throw new RuntimeException("게시한 상태에서는 설명이 필요합니다.");
+            }
+        }
     }
 
     public void publish() {

--- a/src/main/java/com/nubble/backend/post/service/PostCommand.java
+++ b/src/main/java/com/nubble/backend/post/service/PostCommand.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.post.service;
 
+import com.nubble.backend.post.shared.PostStatusDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,10 @@ public class PostCommand {
             String title,
             String content,
             long userId,
-            long boardId
+            long boardId,
+            PostStatusDto status,
+            String thumbnailUrl,
+            String description
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.nubble.backend.post.service;
 import com.nubble.backend.board.domain.Board;
 import com.nubble.backend.board.service.BoardRepository;
 import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
 import com.nubble.backend.user.domain.User;
@@ -31,6 +32,9 @@ public class PostService {
                 .content(command.content())
                 .user(user)
                 .board(board)
+                .status(PostStatus.valueOf(command.status().name()))
+                .thumbnailUrl(command.thumbnailUrl())
+                .description(command.description())
                 .build();
 
         return postRepository.save(newPost)

--- a/src/main/java/com/nubble/backend/post/shared/PostStatusDto.java
+++ b/src/main/java/com/nubble/backend/post/shared/PostStatusDto.java
@@ -1,0 +1,5 @@
+package com.nubble.backend.post.shared;
+
+public enum PostStatusDto {
+    PUBLISHED, DRAFT
+}

--- a/src/test/java/com/nubble/backend/customassert/PostAssert.java
+++ b/src/test/java/com/nubble/backend/customassert/PostAssert.java
@@ -1,0 +1,53 @@
+package com.nubble.backend.customassert;
+
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostStatus;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public class PostAssert extends AbstractAssert<PostAssert, Post> {
+
+    private PostAssert(Post actual) {
+        super(actual, PostAssert.class);
+        isNotNull();
+    }
+
+    public static PostAssert assertThat(Post actual) {
+        return new PostAssert(actual);
+    }
+
+    public PostAssert hasId(Long expectedId) {
+        Assertions.assertThat(actual.getId()).isEqualTo(expectedId);
+        return this;
+    }
+
+    public PostAssert hasTitle(String expectedTitle) {
+        Assertions.assertThat(actual.getTitle()).isEqualTo(expectedTitle);
+        return this;
+    }
+
+    public PostAssert hasContent(String expectedContent) {
+        Assertions.assertThat(actual.getContent()).isEqualTo(expectedContent);
+        return this;
+    }
+
+    public PostAssert hasUserId(Long expectedUserId) {
+        Assertions.assertThat(actual.getUser().getId()).isEqualTo(expectedUserId);
+        return this;
+    }
+
+    public PostAssert hasStatus(PostStatus expectedStatus) {
+        Assertions.assertThat(actual.getStatus()).isEqualTo(expectedStatus);
+        return this;
+    }
+
+    public PostAssert hasThumbnailUrl(String expectedThumbnailUrl) {
+        Assertions.assertThat(actual.getThumbnailUrl()).isEqualTo(expectedThumbnailUrl);
+        return this;
+    }
+
+    public PostAssert hasDescription(String expectedDescription) {
+        Assertions.assertThat(actual.getDescription()).isEqualTo(expectedDescription);
+        return this;
+    }
+}

--- a/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/controller/PostApiControllerTest.java
@@ -14,12 +14,14 @@ import com.nubble.backend.post.controller.PostRequest.PostPublishRequest;
 import com.nubble.backend.post.controller.PostResponse.PostCreateResponse;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostService;
+import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.session.domain.Session;
 import com.nubble.backend.session.service.SessionRepository;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,30 +59,52 @@ class PostApiControllerTest {
     @MockBean
     private PostService postService;
 
-    @DisplayName("로그인된 유저가 게시글을 작성합니다.")
-    @Test
-    void createPost_success() throws Exception {
-        // given
-        User user = UserFixture.aUser().build();
+    private User user;
+    private Session session;
+
+    @BeforeEach
+    void initializeFixtures() {
+        user = UserFixture.aUser().build();
         userRepository.save(user);
-        Session session = Session.builder()
+
+        session = Session.builder()
                 .user(user)
                 .accessId(UUID.randomUUID().toString())
                 .expireAt(LocalDateTime.now().plusDays(1))
                 .build();
         sessionRepository.save(session);
+    }
 
+    @DisplayName("로그인된 유저가 임시 게시글을 작성합니다.")
+    @Test
+    void createPost_success() throws Exception {
+        // given
         PostCreateRequest request = PostCreateRequest.builder()
                 .title("제목입니다.")
                 .content("내용입니다")
+                .boardId(1L)
+                .status(PostStatusDto.DRAFT)
                 .build();
-        String requestJson = objectMapper.writeValueAsString(request);
 
         PostCreateCommand command = postCommandMapper.toPostCreateCommand(request, user.getId());
         long newPostId = 1L;
         given(postService.createPost(command))
                 .willReturn(newPostId);
 
+        /*
+        HTTP Request:
+        POST /posts
+        Content-Type: application/json
+        SESSION-ID: {sessionAccessId}
+
+        {
+            "title": "제목입니다.",
+            "content": "내용입니다",
+            "boardId": 1,
+            "status": "DRAFT"
+        }
+        */
+        String requestJson = objectMapper.writeValueAsString(request);
         MockHttpServletRequestBuilder requestBuilder = post("/posts")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("SESSION-ID", session.getAccessId())
@@ -89,7 +113,15 @@ class PostApiControllerTest {
         PostCreateResponse response = postResponseMapper.toPostCreateResponse(newPostId);
         String responseJson = objectMapper.writeValueAsString(response);
 
-        // when & then
+        /*
+        HTTP Response:
+        HTTP/1.1 201 Created
+        Content-Type: application/json
+
+        {
+          "postId": 1
+        }
+        */
         mockMvc.perform(requestBuilder)
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -101,15 +133,6 @@ class PostApiControllerTest {
     @Test
     void publishPost() throws Exception {
         // given
-        User user = UserFixture.aUser().build();
-        userRepository.save(user);
-        Session session = Session.builder()
-                .user(user)
-                .accessId(UUID.randomUUID().toString())
-                .expireAt(LocalDateTime.now().plusDays(1))
-                .build();
-        sessionRepository.save(session);
-
         PostPublishRequest request = PostPublishRequest.builder()
                 .thumbnailUrl("https://example.com/thumbnail.jpg")
                 .description("설명입니다.")

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -6,11 +6,13 @@ import com.nubble.backend.board.domain.Board;
 import com.nubble.backend.board.service.BoardRepository;
 import com.nubble.backend.category.domain.Category;
 import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.customassert.PostAssert;
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostPublishCommand;
+import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
 import java.util.Optional;
@@ -42,8 +44,11 @@ class PostServiceTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    private User user;
+
     @BeforeEach
     void setup() {
+        // 게시글이 속해있는 카테고리와 게시판을 생성한다.
         Category category = Category.builder()
                 .name("루트 카테고리")
                 .build();
@@ -54,20 +59,22 @@ class PostServiceTest {
                 .name("게시판 이름")
                 .build();
         boardRepository.save(board);
+
+        // 게시글을 작성할 유저를 생성한다.
+        user = UserFixture.aUser().build();
+        userRepository.save(user);
     }
 
-    @DisplayName("게시글을 생성한다.")
+    @DisplayName("임시 상태의 게시글을 생성한다.")
     @Test
-    void createPost_success() {
-        User user = UserFixture.aUser().build();
-        userRepository.save(user);
-
+    void createPost_shouldCreatePostWithDraftStatus() {
         // given
         PostCreateCommand command = PostCreateCommand.builder()
                 .title("제목입니다.")
                 .content("내용입니다.")
                 .userId(user.getId())
                 .boardId(board.getId())
+                .status(PostStatusDto.DRAFT)
                 .build();
 
         // when
@@ -77,22 +84,20 @@ class PostServiceTest {
         Optional<Post> postOptional = postRepository.findById(newPostId);
 
         assertThat(postOptional).isPresent();
-        assertThat(postOptional.get().getId()).isEqualTo(newPostId);
-        assertThat(postOptional.get().getTitle()).isEqualTo(command.title());
-        assertThat(postOptional.get().getContent()).isEqualTo(command.content());
-        assertThat(postOptional.get().getUser().getId()).isEqualTo(user.getId());
-        assertThat(postOptional.get().getStatus()).isEqualTo(PostStatus.DRAFT);
-        assertThat(postOptional.get().getThumbnailUrl()).isNull();
-        assertThat(postOptional.get().getDescription()).isNull();
+        PostAssert.assertThat(postOptional.get())
+                .hasId(newPostId)
+                .hasTitle(command.title())
+                .hasContent(command.content())
+                .hasUserId(user.getId())
+                .hasStatus(PostStatus.valueOf(command.status().name()))
+                .hasThumbnailUrl(null)
+                .hasDescription(null);
     }
 
     @DisplayName("게시글의 주인이 게시글을 게시합니다.")
     @Test
     void test() {
         // given
-        User user = UserFixture.aUser().build();
-        userRepository.save(user);
-
         PostCreateCommand postCreateCommand = PostCreateCommand.builder()
                 .title("제목입니다.")
                 .content("내용입니다.")

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -94,6 +94,37 @@ class PostServiceTest {
                 .hasDescription(null);
     }
 
+    @DisplayName("게시 상태의 게시글을 생성한다.")
+    @Test
+    void createPost_shouldCreatePostWithPublishedStatus() {
+        // given
+        PostCreateCommand command = PostCreateCommand.builder()
+                .title("제목입니다.")
+                .content("내용입니다.")
+                .userId(user.getId())
+                .boardId(board.getId())
+                .status(PostStatusDto.PUBLISHED)
+                .thumbnailUrl("https://example.com")
+                .description("요약 내용입니다.")
+                .build();
+
+        // when
+        long newPostId = postService.createPost(command);
+
+        // then
+        Optional<Post> postOptional = postRepository.findById(newPostId);
+
+        assertThat(postOptional).isPresent();
+        PostAssert.assertThat(postOptional.get())
+                .hasId(newPostId)
+                .hasTitle(command.title())
+                .hasContent(command.content())
+                .hasUserId(user.getId())
+                .hasStatus(PostStatus.valueOf(command.status().name()))
+                .hasThumbnailUrl(command.thumbnailUrl())
+                .hasDescription(command.description());
+    }
+
     @DisplayName("게시글의 주인이 게시글을 게시합니다.")
     @Test
     void test() {


### PR DESCRIPTION
## 요청
```http
POST /posts
Content-Type: application/json
SESSION-ID: {sessionAccessId}

{
    "title": "제목입니다.",
    "content": "내용입니다",
    "boardId": 1,
    "status": "DRAFT",
    "thumbnailUrl": "https://example.com",
    "description": "게시글 요약입니다."
}
```

## 응답
```http
HTTP/1.1 201 Created
Content-Type: application/json

{
  "postId": 1
}
```