### PR TITLE
feat: 게시판과 매핑된 게시글 조회 엔드포인트 구현

### DIFF
--- a/src/main/java/com/nubble/backend/board/controller/BoardApiController.java
+++ b/src/main/java/com/nubble/backend/board/controller/BoardApiController.java
@@ -1,0 +1,32 @@
+package com.nubble.backend.board.controller;
+
+import com.nubble.backend.post.service.PostInfo;
+import com.nubble.backend.post.service.PostService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/boards")
+@RequiredArgsConstructor
+public class BoardApiController {
+
+    private final PostService postService;
+    private final BoardResponseMapper boardResponseMapper;
+
+    @GetMapping(
+            path = "/{boardId}",
+            produces= MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<BoardResponse.PostsDto> findByBoardId(@PathVariable Long boardId) {
+        List<PostInfo.PostDto> postsByBoardId = postService.findPostsByBoardId(boardId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(boardResponseMapper.toPostsDto(postsByBoardId));
+    }
+}

--- a/src/main/java/com/nubble/backend/board/controller/BoardResponse.java
+++ b/src/main/java/com/nubble/backend/board/controller/BoardResponse.java
@@ -1,0 +1,26 @@
+package com.nubble.backend.board.controller;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardResponse {
+
+    @Builder
+    public record PostDto(
+            long id,
+            String title,
+            String thumbnailUrl,
+            String description
+    ) {
+
+    }
+
+    public record PostsDto(
+            List<PostDto> posts
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/board/controller/BoardResponseMapper.java
+++ b/src/main/java/com/nubble/backend/board/controller/BoardResponseMapper.java
@@ -1,0 +1,26 @@
+package com.nubble.backend.board.controller;
+
+import com.nubble.backend.board.controller.BoardResponse.PostsDto;
+import com.nubble.backend.post.service.PostInfo;
+import java.util.List;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface BoardResponseMapper {
+
+    BoardResponse.PostDto toPostDto(PostInfo.PostDto postDto);
+
+    default BoardResponse.PostsDto toPostsDto(List<PostInfo.PostDto> posts) {
+        List<BoardResponse.PostDto> list = posts.stream()
+                .map(this::toPostDto)
+                .toList();
+
+        return new PostsDto(list);
+    }
+}

--- a/src/main/java/com/nubble/backend/post/service/PostInfo.java
+++ b/src/main/java/com/nubble/backend/post/service/PostInfo.java
@@ -1,0 +1,22 @@
+package com.nubble.backend.post.service;
+
+import com.nubble.backend.post.shared.PostStatusDto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostInfo {
+
+    @Builder
+    public record PostDto(
+            long id,
+            String title,
+            String content,
+            String thumbnailUrl,
+            String description,
+            PostStatusDto status,
+            long userId,
+            long boardId) {
+    }
+}

--- a/src/main/java/com/nubble/backend/post/service/PostInfoMapper.java
+++ b/src/main/java/com/nubble/backend/post/service/PostInfoMapper.java
@@ -1,0 +1,19 @@
+package com.nubble.backend.post.service;
+
+import com.nubble.backend.post.domain.Post;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface PostInfoMapper {
+
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "boardId", source = "board.id")
+    PostInfo.PostDto toPostDto(Post post);
+}

--- a/src/main/java/com/nubble/backend/post/service/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/service/PostRepository.java
@@ -1,8 +1,10 @@
 package com.nubble.backend.post.service;
 
 import com.nubble.backend.post.domain.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    List<Post> findAllByBoardId(long boardId);
 }

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -6,8 +6,11 @@ import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostUpdateCommand;
+import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,5 +60,24 @@ public class PostService {
                 PostStatus.valueOf(command.status().name()),
                 board
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostInfo.PostDto> findPostsByBoardId(long boardId) {
+        return new ArrayList<>();
+    }
+
+    public class PostInfo {
+
+        public record PostDto(
+                long id,
+                String title,
+                String content,
+                String thumbnailUrl,
+                String description,
+                PostStatusDto status,
+                long userId,
+                long boardId) {
+        }
     }
 }

--- a/src/main/java/com/nubble/backend/post/service/PostService.java
+++ b/src/main/java/com/nubble/backend/post/service/PostService.java
@@ -6,10 +6,8 @@ import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostUpdateCommand;
-import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
+    private final PostInfoMapper postInfoMapper;
 
     @Transactional
     public long createPost(PostCreateCommand command) {
@@ -64,20 +63,10 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public List<PostInfo.PostDto> findPostsByBoardId(long boardId) {
-        return new ArrayList<>();
+        return postRepository.findAllByBoardId(boardId).stream()
+                .map(postInfoMapper::toPostDto)
+                .toList();
     }
 
-    public class PostInfo {
 
-        public record PostDto(
-                long id,
-                String title,
-                String content,
-                String thumbnailUrl,
-                String description,
-                PostStatusDto status,
-                long userId,
-                long boardId) {
-        }
-    }
 }

--- a/src/test/java/com/nubble/backend/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/board/controller/BoardApiControllerTest.java
@@ -1,0 +1,72 @@
+package com.nubble.backend.board.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.fixture.service.PostInfoFixture;
+import com.nubble.backend.post.service.PostInfo;
+import com.nubble.backend.post.service.PostService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class BoardApiControllerTest {
+
+    @MockBean
+    private PostService postService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BoardResponseMapper boardResponseMapper;
+
+    @DisplayName("boarId와 매핑된 게시글들을 조회한다.")
+    @Test
+    void findByBoardId_shouldReturnPostsMappedToBoardId() throws Exception {
+        // http request
+        long boardId = 1L;
+        MockHttpServletRequestBuilder requestBuilder = get("/boards/{boardId}", boardId);
+
+        // boardId와 매핑된 게시글들
+        int postCount = 5;
+        List<PostInfo.PostDto> postsDto = new ArrayList<>();
+        for (int postId = 1; postId <= postCount; postId++) {
+            postsDto.add(PostInfoFixture.aPostDto()
+                    .withId(postId)
+                    .withUserId(2L)
+                    .withBoardId(3L)
+                    .build());
+        }
+        given(postService.findPostsByBoardId(boardId))
+                .willReturn(postsDto);
+
+        // http response
+        BoardResponse.PostsDto postsDtoResponse = boardResponseMapper.toPostsDto(postsDto);
+
+        // 엔드포인트 호출
+        String responseJson = objectMapper.writeValueAsString(postsDtoResponse);
+        mockMvc.perform(requestBuilder)
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(responseJson))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
+++ b/src/test/java/com/nubble/backend/category/controller/CategoryApiControllerTest.java
@@ -62,29 +62,28 @@ class CategoryApiControllerTest {
                 .willReturn(infos);
 
         /*
-          HTTP Request:
-          GET /categories HTTP/1.1
-          Host: localhost:8080
+        HTTP Request:
+        GET /categories
          */
         MockHttpServletRequestBuilder requestBuilder = get("/categories");
 
         /*
-           HTTP Response:
-          HTTP/1.1 200 OK
-          Content-Type: application/json
+        HTTP Response:
+        HTTP/1.1 200 OK
+        Content-Type: application/json
 
-          {
+        {
             "categories": [
-              {
-                "id": 1,
-                "name": "코딩테스트"
-              },
-              {
-                "id": 2,
-                "name": "스터디"
-              }
+                {
+                    "id": 1,
+                    "name": "코딩테스트"
+                },
+                {
+                    "id": 2,
+                    "name": "스터디"
+                }
             ]
-          }
+        }
          */
         CategoriesDto responses = categoryResponseMapper.toCategoryFindResponses(infos);
         mockMvc.perform(requestBuilder)

--- a/src/test/java/com/nubble/backend/fixture/BoardFixture.java
+++ b/src/test/java/com/nubble/backend/fixture/BoardFixture.java
@@ -1,0 +1,28 @@
+package com.nubble.backend.fixture;
+
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.category.domain.Category;
+
+public class BoardFixture {
+    private static final String DEFAULT_NAME = "스터디";
+
+    private final Board.BoardBuilder builder;
+
+    public static BoardFixture aBoard() {
+        return new BoardFixture();
+    }
+
+    private  BoardFixture() {
+        this.builder = Board.builder()
+                .name(DEFAULT_NAME);
+    }
+
+    public Board build() {
+        return this.builder.build();
+    }
+
+    public BoardFixture withCategory(Category category) {
+        builder.category(category);
+        return this;
+    }
+}

--- a/src/test/java/com/nubble/backend/fixture/PostFixture.java
+++ b/src/test/java/com/nubble/backend/fixture/PostFixture.java
@@ -2,14 +2,16 @@ package com.nubble.backend.fixture;
 
 import com.nubble.backend.board.domain.Board;
 import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.user.domain.User;
 
 public class PostFixture {
 
-    private static final String DEFAULT_TITLE = "제목입니다.";
-    private static final String DEFAULT_CONTENT = "내용입니다.";
-    private static final String DEFAULT_THUMBNAIL_URL = "썸네일의 URL입니다.";
-    private static final String DEFAULT_DESCRIPTION = "요약입니다.";
+    public static final String DEFAULT_TITLE = "제목입니다.";
+    public static final String DEFAULT_CONTENT = "내용입니다.";
+    public static final String DEFAULT_THUMBNAIL_URL = "썸네일의 URL입니다.";
+    public static final String DEFAULT_DESCRIPTION = "요약입니다.";
+    public static final PostStatus DEFAULT_POST_STATUS = PostStatus.PUBLISHED;
 
     private final Post.PostBuilder builder;
 
@@ -22,7 +24,8 @@ public class PostFixture {
                 .title(DEFAULT_TITLE)
                 .content(DEFAULT_CONTENT)
                 .thumbnailUrl(DEFAULT_THUMBNAIL_URL)
-                .description(DEFAULT_DESCRIPTION);
+                .description(DEFAULT_DESCRIPTION)
+                .status(DEFAULT_POST_STATUS);
     }
 
     public Post build() {

--- a/src/test/java/com/nubble/backend/fixture/PostFixture.java
+++ b/src/test/java/com/nubble/backend/fixture/PostFixture.java
@@ -1,0 +1,41 @@
+package com.nubble.backend.fixture;
+
+import com.nubble.backend.board.domain.Board;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.user.domain.User;
+
+public class PostFixture {
+
+    private static final String DEFAULT_TITLE = "제목입니다.";
+    private static final String DEFAULT_CONTENT = "내용입니다.";
+    private static final String DEFAULT_THUMBNAIL_URL = "썸네일의 URL입니다.";
+    private static final String DEFAULT_DESCRIPTION = "요약입니다.";
+
+    private final Post.PostBuilder builder;
+
+    public static PostFixture aPost() {
+        return new PostFixture();
+    }
+
+    private PostFixture() {
+        this.builder = Post.builder()
+                .title(DEFAULT_TITLE)
+                .content(DEFAULT_CONTENT)
+                .thumbnailUrl(DEFAULT_THUMBNAIL_URL)
+                .description(DEFAULT_DESCRIPTION);
+    }
+
+    public Post build() {
+        return this.builder.build();
+    }
+
+    public PostFixture withUser(User user) {
+        builder.user(user);
+        return this;
+    }
+
+    public PostFixture withBoard(Board board) {
+        builder.board(board);
+        return this;
+    }
+}

--- a/src/test/java/com/nubble/backend/fixture/service/PostInfoFixture.java
+++ b/src/test/java/com/nubble/backend/fixture/service/PostInfoFixture.java
@@ -1,0 +1,48 @@
+package com.nubble.backend.fixture.service;
+
+import com.nubble.backend.fixture.PostFixture;
+import com.nubble.backend.post.service.PostInfo;
+import com.nubble.backend.post.shared.PostStatusDto;
+
+public class PostInfoFixture {
+
+    private PostInfoFixture() {
+    }
+
+    public static PostDtoFixture aPostDto() {
+        return new PostDtoFixture();
+    }
+
+    public static class PostDtoFixture {
+
+        private final PostInfo.PostDto.PostDtoBuilder builder;
+
+        private PostDtoFixture() {
+            builder = PostInfo.PostDto.builder()
+                    .title(PostFixture.DEFAULT_TITLE)
+                    .content(PostFixture.DEFAULT_CONTENT)
+                    .thumbnailUrl(PostFixture.DEFAULT_THUMBNAIL_URL)
+                    .description(PostFixture.DEFAULT_DESCRIPTION)
+                    .status(PostStatusDto.valueOf(PostFixture.DEFAULT_POST_STATUS.name()));
+        }
+
+        public PostInfo.PostDto build() {
+            return builder.build();
+        }
+
+        public PostDtoFixture withId(long id) {
+            builder.id(id);
+            return this;
+        }
+
+        public PostDtoFixture withUserId(long userId) {
+            builder.userId(userId);
+            return this;
+        }
+
+        public PostDtoFixture withBoardId(long boardId) {
+            builder.boardId(boardId);
+            return this;
+        }
+    }
+}

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -14,7 +14,7 @@ import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostUpdateCommand;
-import com.nubble.backend.post.service.PostService.PostInfo.PostDto;
+import com.nubble.backend.post.service.PostInfo.PostDto;
 import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;

--- a/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/service/PostServiceTest.java
@@ -7,14 +7,19 @@ import com.nubble.backend.board.service.BoardRepository;
 import com.nubble.backend.category.domain.Category;
 import com.nubble.backend.category.service.CategoryRepository;
 import com.nubble.backend.customassert.PostAssert;
+import com.nubble.backend.fixture.BoardFixture;
+import com.nubble.backend.fixture.PostFixture;
 import com.nubble.backend.fixture.UserFixture;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostStatus;
 import com.nubble.backend.post.service.PostCommand.PostCreateCommand;
 import com.nubble.backend.post.service.PostCommand.PostUpdateCommand;
+import com.nubble.backend.post.service.PostService.PostInfo.PostDto;
 import com.nubble.backend.post.shared.PostStatusDto;
 import com.nubble.backend.user.domain.User;
 import com.nubble.backend.user.service.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +42,6 @@ class PostServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    private Board board;
 
     @Autowired
     private CategoryRepository categoryRepository;
@@ -45,12 +49,14 @@ class PostServiceTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    Category category;
+    private Board board;
     private User user;
 
     @BeforeEach
     void setup() {
         // 게시글이 속해있는 카테고리와 게시판을 생성한다.
-        Category category = Category.builder()
+        category = Category.builder()
                 .name("루트 카테고리")
                 .build();
         categoryRepository.save(category);
@@ -237,5 +243,44 @@ class PostServiceTest {
         Assertions.assertThatThrownBy(() -> postService.updatePost(postUpdateCommand))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("게시글의 주인이 아닙니다.");
+    }
+
+    @DisplayName("boardId와 매핑되어 있는 게시글들을 가져온다.")
+    @Test
+    void findPostsByBoardId_ShouldReturnPostsMappedToBoardId() {
+        // 가져오려는 게시판에 게시글을 작성한다.
+        int postCount = 5;
+        List<Post> posts = new ArrayList<>();
+        for (int i = 0; i < postCount; i++) {
+            Post post = PostFixture.aPost()
+                    .withBoard(board)
+                    .withUser(user)
+                    .build();
+            posts.add(post);
+        }
+        postRepository.saveAll(posts);
+
+        // 다른 게시판에 게시글을 작성한다.
+        Board otherBoard = BoardFixture.aBoard().withCategory(category)
+                .build();
+        boardRepository.save(otherBoard);
+
+        int otherPostCount = 3;
+        List<Post> otherPosts = new ArrayList<>();
+        for (int i = 0; i < otherPostCount; i++) {
+            Post post = PostFixture.aPost()
+                    .withBoard(otherBoard)
+                    .withUser(user)
+                    .build();
+            otherPosts.add(post);
+        }
+        postRepository.saveAll(otherPosts);
+
+        // 게시판과 매핑된 게시글을 가져온다.
+        List<PostDto> postsByBoardId = postService.findPostsByBoardId(board.getId());
+
+        // 매핑된 게시글들만 가져오는 것을 검증한다.
+        assertThat(postsByBoardId).hasSize(postCount)
+                .allMatch(post -> post.boardId() == board.getId());
     }
 }


### PR DESCRIPTION
## 요청
```http
GET /boards/1 HTTP/1.1
Host: example.com
Accept: application/json
```

## 응답
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
  "posts": [
    {
      "id": 101,
      "title": "샘플 게시물 제목",
      "thumbnailUrl": "http://example.com/image.jpg",
      "description": "이것은 게시물에 대한 샘플 설명입니다."
    },
    {
      "id": 102,
      "title": "다른 게시물 제목",
      "thumbnailUrl": "http://example.com/image2.jpg",
      "description": "이것은 다른 샘플 설명입니다."
    }
  ]
}
```