### PR TITLE
feat: 게시글 좋아요 api 구현

### DIFF
--- a/src/main/java/com/nubble/backend/post/domain/PostLike.java
+++ b/src/main/java/com/nubble/backend/post/domain/PostLike.java
@@ -1,0 +1,59 @@
+package com.nubble.backend.post.domain;
+
+import com.nubble.backend.userold.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@Entity
+@Table(name = "post_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"post_id", "user_id"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime likedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.likedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    protected PostLike(Post post, User user) {
+        Assert.notNull(post, "좋아요시, 게시글 지정은 필수입니다.");
+        Assert.notNull(user, "좋아요할 유저를 지정해주세요.");
+
+        this.post = post;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
+++ b/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
@@ -1,0 +1,43 @@
+package com.nubble.backend.post.feature.like;
+
+import com.nubble.backend.config.interceptor.session.SessionRequired;
+import com.nubble.backend.config.resolver.UserSession;
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LikePostController {
+
+    private final LikePostService likePostService;
+
+    @SessionRequired
+    @PutMapping(
+            path = "/posts/{postId:\\d+}/likes",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<LikePostResponse> likePost(
+            @PathVariable long postId,
+            UserSession userSession
+    ) {
+        LikePostCommand command = LikePostCommand.builder()
+                .postId(postId)
+                .userId(userSession.userId()).build();
+
+        Long newLikeId = likePostService.likePost(command);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new LikePostResponse(newLikeId));
+    }
+
+    public record LikePostResponse(
+            Long newLikeId
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
+++ b/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
@@ -22,10 +22,7 @@ public class LikePostController {
             path = "/posts/{postId:\\d+}/likes",
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<LikePostResponse> likePost(
-            @PathVariable long postId,
-            UserSession userSession
-    ) {
+    public ResponseEntity<LikePostResponse> likePost(@PathVariable long postId, UserSession userSession) {
         LikePostCommand command = LikePostCommand.builder()
                 .postId(postId)
                 .userId(userSession.userId()).build();

--- a/src/main/java/com/nubble/backend/post/feature/like/LikePostService.java
+++ b/src/main/java/com/nubble/backend/post/feature/like/LikePostService.java
@@ -1,0 +1,47 @@
+package com.nubble.backend.post.feature.like;
+
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.post.domain.PostStatus;
+import com.nubble.backend.post.repository.PostLikeRepository;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikePostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public Long likePost(LikePostCommand command) {
+        Post post = postRepository.getPostById(command.postId);
+        User user = userRepository.getUserById(command.userId);
+        if (post.getStatus() == PostStatus.DRAFT) {
+            throw new IllegalStateException("임시 게시글에는 좋아요를 누를 수 없습니다.");
+        }
+        if (postLikeRepository.existsByPostAndUser(post, user)) {
+            throw new IllegalStateException("이미 좋아요를 누른 게시글입니다.");
+        }
+
+        PostLike postLike = PostLike.builder()
+                .post(post)
+                .user(user).build();
+        return postLikeRepository.save(postLike)
+                .getId();
+    }
+
+    @Builder
+    public record LikePostCommand(
+            Long postId,
+            Long userId
+    ) {
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostController.java
+++ b/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostController.java
@@ -1,0 +1,31 @@
+package com.nubble.backend.post.feature.unlinke;
+
+import com.nubble.backend.config.interceptor.session.SessionRequired;
+import com.nubble.backend.config.resolver.UserSession;
+import com.nubble.backend.post.feature.like.LikePostController.LikePostResponse;
+import com.nubble.backend.post.feature.unlinke.UnlikePostService.UnlikePostCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UnlikePostController {
+
+    private final UnlikePostService unlikePostService;
+
+    @SessionRequired
+    @DeleteMapping(path = "/posts/{postId:\\d+}/likes")
+    public ResponseEntity<LikePostResponse> unlikePost(@PathVariable long postId, UserSession userSession) {
+        UnlikePostCommand command = UnlikePostCommand.builder()
+                .postId(postId)
+                .userId(userSession.userId()).build();
+
+        unlikePostService.unlikePost(command);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostService.java
+++ b/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostService.java
@@ -1,0 +1,28 @@
+package com.nubble.backend.post.feature.unlinke;
+
+import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.post.repository.PostLikeRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UnlikePostService {
+
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public void unlikePost(UnlikePostCommand command) {
+        PostLike postLike = postLikeRepository.getPostLike(command.postId, command.userId);
+        postLikeRepository.delete(postLike);
+    }
+
+    @Builder
+    public record UnlikePostCommand(
+            Long postId,
+            Long userId
+    ) {
+    }
+}

--- a/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
@@ -3,9 +3,18 @@ package com.nubble.backend.post.repository;
 import com.nubble.backend.post.domain.Post;
 import com.nubble.backend.post.domain.PostLike;
 import com.nubble.backend.userold.domain.User;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndUser(Post post, User user);
+
+    Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
+
+    default PostLike getPostLike(Long postId, Long userId) {
+        return findByPostIdAndUserId(postId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("좋아요가 존재하지 않습니다."));
+    }
 }

--- a/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
@@ -1,0 +1,11 @@
+package com.nubble.backend.post.repository;
+
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.userold.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    boolean existsByPostAndUser(Post post, User user);
+}

--- a/src/test/java/com/nubble/backend/post/feature/like/LikePostControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/like/LikePostControllerTest.java
@@ -1,0 +1,93 @@
+package com.nubble.backend.post.feature.like;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.session.domain.Session;
+import com.nubble.backend.userold.session.service.SessionRepository;
+import com.nubble.backend.userold.session.service.SessionService;
+import com.nubble.backend.utils.fixture.domain.AuthSessionFixture;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LikePostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private SessionRepository sessionRepository;
+
+    @MockBean
+    private LikePostService likePostService;
+
+    private Session session;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = Mockito.spy(UserFixture.aUser().build());
+        given(user.getId())
+                .willReturn(771L);
+
+        session = AuthSessionFixture.aAuthSession()
+                .withUser(user).build();
+
+        given(sessionRepository.findByAccessId(session.getAccessId()))
+                .willReturn(Optional.ofNullable(session));
+    }
+
+    @DisplayName("멤버가 게시글에 좋아요를 누른다")
+    @Test
+    void success() throws Exception {
+        // http request
+        long postId = 23L;
+        MockHttpServletRequestBuilder requestBuilder = put("/posts/{postId}/likes", postId)
+                .header("SESSION-ID", session.getAccessId());
+
+        // 좋아요를 누른다
+        LikePostCommand command = LikePostCommand.builder()
+                .userId(user.getId())
+                .postId(postId).build();
+
+        long newLikeId = 102L;
+        given(likePostService.likePost(command))
+                .willReturn(newLikeId);
+
+        // http response
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(String.format("""
+                        {
+                            "newLikeId": %d
+                        }
+                        """, newLikeId)))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/nubble/backend/post/feature/like/LikePostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/like/LikePostServiceTest.java
@@ -1,0 +1,118 @@
+package com.nubble.backend.post.feature.like;
+
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
+import com.nubble.backend.post.fixture.PostFixture;
+import com.nubble.backend.post.repository.PostLikeRepository;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import com.nubble.backend.utils.fixture.domain.BoardFixture;
+import com.nubble.backend.utils.fixture.domain.CategoryFixture;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class LikePostServiceTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LikePostService likePostService;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    private User user;
+    private Post publishedPost;
+    private Post draftPost;
+
+    @BeforeEach
+    void setUp() {
+        Category category = CategoryFixture.aCategory().build();
+        categoryRepository.save(category);
+
+        Board board = BoardFixture.aBoard()
+                .category(category).build();
+        boardRepository.save(board);
+
+        user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        publishedPost = PostFixture.aPublishedPost()
+                .user(user)
+                .board(board).build();
+        postRepository.save(publishedPost);
+
+        draftPost = PostFixture.aDraftPost()
+                .user(user)
+                .board(board).build();
+        postRepository.save(draftPost);
+    }
+
+    @DisplayName("유저가 게시글에 좋아요를 누른다")
+    @Test
+    void success() {
+        // 게시글에 좋아요를 누른다
+        LikePostCommand command = LikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+
+        Long postLikeId = likePostService.likePost(command);
+
+        // 좋아요 확인
+        Assertions.assertThat(postLikeRepository.findById(postLikeId)).isPresent();
+    }
+
+    @DisplayName("임시 게시글에는 좋아요를 누를 수 없다")
+    @Test
+    void test() {
+        // 임시 게시글에 좋아요를 누른다
+        // 예외를 발생시킨다
+        LikePostCommand command = LikePostCommand.builder()
+                .postId(draftPost.getId())
+                .userId(user.getId()).build();
+
+        Assertions.assertThatThrownBy(() -> likePostService.likePost(command))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("임시 게시글에는 좋아요를 누를 수 없습니다.");
+    }
+
+    @DisplayName("이미 좋아요를 누른 게시글에 다시 좋아요를 누를 수 없다")
+    @Test
+    void throwException() {
+        // 좋아요를 누른 상태로 만든다
+        LikePostCommand command = LikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+
+        likePostService.likePost(command);
+
+        // 좋아요를 다시 한번 요청한다
+        // 예외를 발생시킨다
+        Assertions.assertThatThrownBy(() -> likePostService.likePost(command))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 좋아요를 누른 게시글입니다.");
+    }
+}

--- a/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostControllerTest.java
@@ -1,12 +1,11 @@
-package com.nubble.backend.post.feature.like;
+package com.nubble.backend.post.feature.unlinke;
 
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
 import com.nubble.backend.userold.domain.User;
 import com.nubble.backend.userold.session.domain.Session;
 import com.nubble.backend.userold.session.service.SessionRepository;
@@ -22,13 +21,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class LikePostControllerTest {
+class UnlikePostControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -40,7 +38,7 @@ class LikePostControllerTest {
     private SessionRepository sessionRepository;
 
     @MockBean
-    private LikePostService likePostService;
+    private UnlikePostService unlikePostService;
 
     private Session session;
     private User user;
@@ -58,32 +56,19 @@ class LikePostControllerTest {
                 .willReturn(Optional.ofNullable(session));
     }
 
-    @DisplayName("멤버가 게시글에 좋아요를 누른다")
+    @DisplayName("게시글 좋아요를 취소한다")
     @Test
     void success() throws Exception {
         // http request
         long postId = 23L;
-        MockHttpServletRequestBuilder requestBuilder = put("/posts/{postId}/likes", postId)
+        MockHttpServletRequestBuilder requestBuilder = delete("/posts/{postId}/likes", postId)
                 .header("SESSION-ID", session.getAccessId());
-
-        // 좋아요를 누른다
-        LikePostCommand command = LikePostCommand.builder()
-                .userId(user.getId())
-                .postId(postId).build();
-
-        long newLikeId = 102L;
-        given(likePostService.likePost(command))
-                .willReturn(newLikeId);
 
         // http response
         mockMvc.perform(requestBuilder)
-                .andExpect(status().isCreated())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().json(String.format("""
-                        {
-                            "newLikeId": %d
-                        }
-                        """, newLikeId)))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(""))
                 .andDo(print());
+
     }
 }

--- a/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostServiceTest.java
@@ -1,0 +1,103 @@
+package com.nubble.backend.post.feature.unlinke;
+
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.post.feature.unlinke.UnlikePostService.UnlikePostCommand;
+import com.nubble.backend.post.fixture.PostFixture;
+import com.nubble.backend.post.repository.PostLikeRepository;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import com.nubble.backend.utils.fixture.domain.BoardFixture;
+import com.nubble.backend.utils.fixture.domain.CategoryFixture;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class UnlikePostServiceTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    @Autowired
+    private UnlikePostService unlikePostService;
+
+    private User user;
+    private Post publishedPost;
+
+    @BeforeEach
+    void setUp() {
+        Category category = CategoryFixture.aCategory().build();
+        categoryRepository.save(category);
+
+        Board board = BoardFixture.aBoard()
+                .category(category).build();
+        boardRepository.save(board);
+
+        user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        publishedPost = PostFixture.aPublishedPost()
+                .user(user)
+                .board(board).build();
+        postRepository.save(publishedPost);
+    }
+
+    @DisplayName("좋아요를 취소한다")
+    @Test
+    void success() {
+        // 좋아요를 한다
+        PostLike postLike = PostLike.builder()
+                .post(publishedPost)
+                .user(user).build();
+        Long postLikeId = postLikeRepository.save(postLike).getId();
+
+        // 좋아요를 취소한다
+        UnlikePostCommand command = UnlikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+
+        unlikePostService.unlikePost(command);
+
+        // 좋아요 취소를 확인한다
+        Assertions.assertThat(postLikeRepository.findById(postLikeId)).isEmpty();
+    }
+
+    @DisplayName("좋아요를 누른 적이 없이, 취소할 수 없다")
+    @Test
+    void throwException() {
+        // 좋아요 취소를 한다
+        // 좋아요 한 적이 없으므로 예외를 발생시킨다
+        UnlikePostCommand command = UnlikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+
+        Assertions.assertThatThrownBy(() -> unlikePostService.unlikePost(command))
+                .isInstanceOf(JpaObjectRetrievalFailureException.class)
+                .hasMessage("좋아요가 존재하지 않습니다.");
+    }
+}


### PR DESCRIPTION
## 좋아요 엔드포인트

- 임시글은 `좋아요`를 할 수 없습니다.
- 이미 `좋아요` 한 게시글에 다시 `좋아요`를 할 수 없습니다.

### http request
```http
PUT /posts/{postId}/likes HTTP/1.1
Host: nubble.kr
SESSION-ID: [SESSIONID]
```

### http response
```http
HTTP/1.1 201 Created
Content-Type: application/json

{
    "newLikeId": 102
}
```

## 좋아요 취소 엔드포인트

- `좋아요` 하지 않은 게시글은 취소할 수 없습니다.

### http request
```http
DELETE /posts/{postId}/likes HTTP/1.1
Host: nubble.kr
SESSION-ID: [SESSIONID]
```

### http response
```http
HTTP/1.1 204 No Content
```
