### PR TITLE
feat: 인기 게시글 조회 및 게시글 좋아요 확인

### DIFF
--- a/src/main/java/com/nubble/backend/post/domain/Post.java
+++ b/src/main/java/com/nubble/backend/post/domain/Post.java
@@ -63,6 +63,8 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private PostStatus status;
 
+    @Column(nullable = false)
+    private int likeCount = 0;
 
     @Builder(builderClassName = "PublishedBuilder", builderMethodName = "publishedBuilder")
     protected Post(

--- a/src/main/java/com/nubble/backend/post/feature/PostDto.java
+++ b/src/main/java/com/nubble/backend/post/feature/PostDto.java
@@ -15,7 +15,8 @@ public record PostDto(
         PostStatus status,
         LocalDateTime createdAt,
         Long userId,
-        Long boardId
+        Long boardId,
+        int likeCount
 ) {
 
     public static PostDto fromDomain(Post post) {
@@ -28,6 +29,7 @@ public record PostDto(
                 .status(post.getStatus())
                 .createdAt(post.getCreatedAt())
                 .userId(post.getUser().getId())
-                .boardId(post.getBoard().getId()).build();
+                .boardId(post.getBoard().getId())
+                .likeCount(post.getLikeCount()).build();
     }
 }

--- a/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardController.java
+++ b/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardController.java
@@ -42,7 +42,8 @@ public class FindAllPostsByBoardController {
             String thumbnailUrl,
             String description,
             String username,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            int likeCount
     ) {
     }
 }

--- a/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardController.java
+++ b/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardController.java
@@ -23,12 +23,9 @@ public class FindAllPostsByBoardController {
             produces= MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<FindAllPostsByBoardResponse> findAllByBoardId(@PathVariable Long boardId) {
         List<PostWithUserDto> dtos = findAllPostsByBoardService.findAllByBoardId(boardId);
-        List<FindPostByBoardResponse> list = dtos.stream()
-                .map(mapper::toResponse)
-                .toList();
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new FindAllPostsByBoardResponse(list));
+                .body(mapper.toResponse(dtos));
     }
 
     public record FindAllPostsByBoardResponse(

--- a/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardMapper.java
+++ b/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardMapper.java
@@ -2,7 +2,9 @@ package com.nubble.backend.post.feature.findallbyboard;
 
 import com.nubble.backend.common.BaseMapperConfig;
 import com.nubble.backend.post.feature.PostWithUserDto;
+import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardController.FindAllPostsByBoardResponse;
 import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardController.FindPostByBoardResponse;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -17,4 +19,12 @@ public interface FindAllPostsByBoardMapper {
     @Mapping(target = "createdAt", source = "post.createdAt")
     @Mapping(target = "likeCount", source = "post.likeCount")
     FindPostByBoardResponse toResponse(PostWithUserDto postWithUserDto);
+
+    default FindAllPostsByBoardResponse toResponse(List<PostWithUserDto> postWithUserDtos) {
+        List<FindPostByBoardResponse> list = postWithUserDtos.stream()
+                .map(this::toResponse)
+                .toList();
+
+        return new FindAllPostsByBoardResponse(list);
+    }
 }

--- a/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardMapper.java
+++ b/src/main/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardMapper.java
@@ -15,5 +15,6 @@ public interface FindAllPostsByBoardMapper {
     @Mapping(target = "description", source = "post.description")
     @Mapping(target = "username", source = "user.username")
     @Mapping(target = "createdAt", source = "post.createdAt")
+    @Mapping(target = "likeCount", source = "post.likeCount")
     FindPostByBoardResponse toResponse(PostWithUserDto postWithUserDto);
 }

--- a/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsController.java
+++ b/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsController.java
@@ -1,0 +1,32 @@
+package com.nubble.backend.post.feature.findpopularposts;
+
+import com.nubble.backend.post.feature.PostWithUserDto;
+import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardController.FindAllPostsByBoardResponse;
+import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FindPopularPostsController {
+
+    private final FindPopularPostsService service;
+    private final FindAllPostsByBoardMapper mapper;
+
+    @GetMapping(
+            path = "/boards/{boardId:\\d+}/posts/popular",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<FindAllPostsByBoardResponse> findPopularPosts(@PathVariable long boardId) {
+        List<PostWithUserDto> dtos = service.findPopularPosts(boardId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(mapper.toResponse(dtos));
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsService.java
+++ b/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsService.java
@@ -1,0 +1,28 @@
+package com.nubble.backend.post.feature.findpopularposts;
+
+import com.nubble.backend.post.feature.PostDto;
+import com.nubble.backend.post.feature.PostWithUserDto;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.user.feature.UserDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FindPopularPostsService {
+
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public List<PostWithUserDto> findPopularPosts() {
+        return postRepository.findAllByOrderByLikeCountDesc().stream()
+                .filter(post -> post.getLikeCount() > 0)
+                .map(post -> {
+                    PostDto postDto = PostDto.fromDomain(post);
+                    UserDto userDto = UserDto.fromDomain(post.getUser());
+                    return new PostWithUserDto(postDto, userDto);})
+                .toList();
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsService.java
+++ b/src/main/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsService.java
@@ -1,5 +1,7 @@
 package com.nubble.backend.post.feature.findpopularposts;
 
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
 import com.nubble.backend.post.feature.PostDto;
 import com.nubble.backend.post.feature.PostWithUserDto;
 import com.nubble.backend.post.repository.PostRepository;
@@ -13,11 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FindPopularPostsService {
 
+    private final BoardRepository boardRepository;
     private final PostRepository postRepository;
 
     @Transactional(readOnly = true)
-    public List<PostWithUserDto> findPopularPosts() {
-        return postRepository.findAllByOrderByLikeCountDesc().stream()
+    public List<PostWithUserDto> findPopularPosts(long boardId) {
+        Board board = boardRepository.getBoardById(boardId);
+
+        return postRepository.findAllByBoardOrderByLikeCountDesc(board).stream()
                 .filter(post -> post.getLikeCount() > 0)
                 .map(post -> {
                     PostDto postDto = PostDto.fromDomain(post);

--- a/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailController.java
+++ b/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailController.java
@@ -46,7 +46,8 @@ public class GetPostDetailController {
             String boardName,
             Long categoryId,
             String categoryName,
-            int likeCount
+            int likeCount,
+            boolean postLiked
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailController.java
+++ b/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailController.java
@@ -45,7 +45,8 @@ public class GetPostDetailController {
             Long boardId,
             String boardName,
             Long categoryId,
-            String categoryName
+            String categoryName,
+            int likeCount
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailFacade.java
+++ b/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailFacade.java
@@ -7,6 +7,9 @@ import com.nubble.backend.category.service.CategoryService;
 import com.nubble.backend.post.feature.PostDto;
 import com.nubble.backend.post.feature.PostWithUserDto;
 import com.nubble.backend.post.feature.getpostdetail.GetPostWithUserService.GetPostWithUserQuery;
+import com.nubble.backend.post.feature.isliked.IsPostLikedQueryMapper;
+import com.nubble.backend.post.feature.isliked.IsPostLikedService;
+import com.nubble.backend.post.feature.isliked.IsPostLikedService.IsPostLikedQuery;
 import com.nubble.backend.user.feature.UserDto;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +20,25 @@ import org.springframework.stereotype.Service;
 public class GetPostDetailFacade {
 
     private final GetPostWithUserService getPostWithUserService;
+    private final IsPostLikedService isPostLikedService;
     private final CategoryService categoryService;
     private final BoardService boardService;
+    private final IsPostLikedQueryMapper isPostLikedQueryMapper;
 
     public GetPostDetailFacadeInfo getPostDetailById(GetPostWithUserQuery query) {
         PostWithUserDto postWithUser = getPostWithUserService.getPostWithUser(query);
         BoardDto board = boardService.getBoardById(postWithUser.post().boardId());
         CategoryDto category = categoryService.getCategoryById(board.categoryId());
 
+        IsPostLikedQuery isPostLikedQuery = isPostLikedQueryMapper.toQuery(query.postId(), query.userId());
+        boolean postLiked = isPostLikedService.isPostLiked(isPostLikedQuery);
+
         return GetPostDetailFacadeInfo.builder()
                 .post(postWithUser.post())
                 .user(postWithUser.user())
                 .board(board)
-                .category(category).build();
+                .category(category)
+                .postLiked(postLiked).build();
     }
 
     @Builder
@@ -37,7 +46,8 @@ public class GetPostDetailFacade {
             PostDto post,
             UserDto user,
             BoardDto board,
-            CategoryDto category
+            CategoryDto category,
+            boolean postLiked
     ) {
 
     }

--- a/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailMapper.java
+++ b/src/main/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailMapper.java
@@ -23,6 +23,7 @@ public interface GetPostDetailMapper {
     @Mapping(target = "boardName", source = "board.name")
     @Mapping(target = "categoryId", source = "category.id")
     @Mapping(target = "categoryName", source = "category.name")
+    @Mapping(target = "likeCount", source = "post.likeCount")
     GetPostDetailResponse toResponse(GetPostDetailFacadeInfo result);
 
     GetPostWithUserQuery toQuery(UserSession userSession, Long postId);

--- a/src/main/java/com/nubble/backend/post/feature/isliked/IsPostLikedQueryMapper.java
+++ b/src/main/java/com/nubble/backend/post/feature/isliked/IsPostLikedQueryMapper.java
@@ -1,0 +1,11 @@
+package com.nubble.backend.post.feature.isliked;
+
+import com.nubble.backend.common.BaseMapperConfig;
+import com.nubble.backend.post.feature.isliked.IsPostLikedService.IsPostLikedQuery;
+import org.mapstruct.Mapper;
+
+@Mapper(config = BaseMapperConfig.class)
+public interface IsPostLikedQueryMapper {
+
+    IsPostLikedQuery toQuery(Long postId, Long userId);
+}

--- a/src/main/java/com/nubble/backend/post/feature/isliked/IsPostLikedService.java
+++ b/src/main/java/com/nubble/backend/post/feature/isliked/IsPostLikedService.java
@@ -1,0 +1,25 @@
+package com.nubble.backend.post.feature.isliked;
+
+import com.nubble.backend.post.repository.PostLikeRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IsPostLikedService {
+
+    private final PostLikeRepository postLikeRepository;
+
+    public boolean isPostLiked(IsPostLikedQuery query) {
+        return postLikeRepository.existsByPostIdAndUserId(query.postId, query.userId);
+    }
+
+    @Builder
+    public record IsPostLikedQuery(
+            Long postId,
+            Long userId
+    ) {
+
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
+++ b/src/main/java/com/nubble/backend/post/feature/like/LikePostController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LikePostController {
 
-    private final LikePostService likePostService;
+    private final LikePostFacade likePostFacade;
 
     @SessionRequired
     @PutMapping(
@@ -27,7 +27,7 @@ public class LikePostController {
                 .postId(postId)
                 .userId(userSession.userId()).build();
 
-        Long newLikeId = likePostService.likePost(command);
+        Long newLikeId = likePostFacade.likePost(command);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new LikePostResponse(newLikeId));
     }

--- a/src/main/java/com/nubble/backend/post/feature/like/LikePostFacade.java
+++ b/src/main/java/com/nubble/backend/post/feature/like/LikePostFacade.java
@@ -1,0 +1,21 @@
+package com.nubble.backend.post.feature.like;
+
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
+import com.nubble.backend.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikePostFacade {
+
+    private final LikePostService likePostService;
+    private final PostRepository postRepository;
+
+    public Long likePost(LikePostCommand command) {
+        Long newPostLikeId = likePostService.likePost(command);
+        postRepository.incrementLikeCount(command.postId());
+
+        return newPostLikeId;
+    }
+}

--- a/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostController.java
+++ b/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UnlikePostController {
 
-    private final UnlikePostService unlikePostService;
+    private final UnlikePostFacade unlikePostFacade;
 
     @SessionRequired
     @DeleteMapping(path = "/posts/{postId:\\d+}/likes")
@@ -24,7 +24,7 @@ public class UnlikePostController {
                 .postId(postId)
                 .userId(userSession.userId()).build();
 
-        unlikePostService.unlikePost(command);
+        unlikePostFacade.unlikePost(command);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
     }

--- a/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostFacade.java
+++ b/src/main/java/com/nubble/backend/post/feature/unlinke/UnlikePostFacade.java
@@ -1,0 +1,21 @@
+package com.nubble.backend.post.feature.unlinke;
+
+import com.nubble.backend.post.feature.unlinke.UnlikePostService.UnlikePostCommand;
+import com.nubble.backend.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UnlikePostFacade {
+
+    private final UnlikePostService unlikePostService;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void unlikePost(UnlikePostCommand command) {
+        unlikePostService.unlikePost(command);
+        postRepository.decrementLikeCount(command.postId());
+    }
+}

--- a/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostLikeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndUser(Post post, User user);
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
 

--- a/src/main/java/com/nubble/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostRepository.java
@@ -3,6 +3,8 @@ package com.nubble.backend.post.repository;
 import com.nubble.backend.post.domain.Post;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
@@ -10,4 +12,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
         return findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다."));
     }
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :postId")
+    void incrementLikeCount(Long postId);
 }

--- a/src/main/java/com/nubble/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.nubble.backend.post.repository;
 
 import com.nubble.backend.post.domain.Post;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +22,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :postId AND p.likeCount > 0")
     void decrementLikeCount(Long postId);
+
+    @EntityGraph(attributePaths = {"user"}) // 연관 데이터를 즉시 로딩
+    List<Post> findAllByOrderByLikeCountDesc();
 }

--- a/src/main/java/com/nubble/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.nubble.backend.post.repository;
 
+import com.nubble.backend.category.board.domain.Board;
 import com.nubble.backend.post.domain.Post;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -24,5 +25,5 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     void decrementLikeCount(Long postId);
 
     @EntityGraph(attributePaths = {"user"}) // 연관 데이터를 즉시 로딩
-    List<Post> findAllByOrderByLikeCountDesc();
+    List<Post> findAllByBoardOrderByLikeCountDesc(Board board);
 }

--- a/src/main/java/com/nubble/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/nubble/backend/post/repository/PostRepository.java
@@ -16,4 +16,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :postId")
     void incrementLikeCount(Long postId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :postId AND p.likeCount > 0")
+    void decrementLikeCount(Long postId);
 }

--- a/src/test/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/findallbyboard/FindAllPostsByBoardControllerTest.java
@@ -57,7 +57,8 @@ class FindAllPostsByBoardControllerTest {
             PostDto postDto = PostDtoFixture.aPostDto()
                     .postId(postId)
                     .userId(user.id())
-                    .boardId(3L).build();
+                    .boardId(3L)
+                    .likeCount(2).build();
             posts.add(PostWithUserDto.builder()
                     .post(postDto)
                     .user(user).build());

--- a/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsControllerTest.java
@@ -1,4 +1,4 @@
-package com.nubble.backend.post.feature.findallbyboard;
+package com.nubble.backend.post.feature.findpopularposts;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nubble.backend.post.feature.PostDto;
 import com.nubble.backend.post.feature.PostWithUserDto;
 import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardController.FindAllPostsByBoardResponse;
+import com.nubble.backend.post.feature.findallbyboard.FindAllPostsByBoardMapper;
 import com.nubble.backend.post.fixture.PostDtoFixture;
 import com.nubble.backend.user.feature.UserDto;
 import com.nubble.backend.user.feature.UserDtoFixture;
@@ -26,10 +27,10 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class FindAllPostsByBoardControllerTest {
+class FindPopularPostsControllerTest {
 
     @MockBean
-    private FindAllPostsByBoardService service;
+    private FindPopularPostsService service;
 
     @Autowired
     private MockMvc mockMvc;
@@ -40,14 +41,14 @@ class FindAllPostsByBoardControllerTest {
     @Autowired
     private FindAllPostsByBoardMapper mapper;
 
-    @DisplayName("게시판에 있는 게시된 글들을 가져온다")
+    @DisplayName("게시판의 인기 게시글들을 가져온다")
     @Test
     void success() throws Exception {
         // http request
         long boardId = 2L;
-        MockHttpServletRequestBuilder requestBuilder = get("/boards/{boardId}", boardId);
+        MockHttpServletRequestBuilder requestBuilder = get("/boards/{boardId}/posts/popular", boardId);
 
-        // 게시판에 있는 글들을 조회
+        // 게시판 내의 인기 게시글들을 조회
         UserDto user = UserDtoFixture.aUserDto().build();
 
         int postCount = 5;
@@ -63,7 +64,7 @@ class FindAllPostsByBoardControllerTest {
                     .user(user).build());
         }
 
-        given(service.findAllByBoardId(boardId))
+        given(service.findPopularPosts(boardId))
                 .willReturn(posts);
 
         // http response

--- a/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsServiceTest.java
@@ -41,6 +41,8 @@ class FindPopularPostsServiceTest {
     @Autowired
     private FindPopularPostsService findPopularPostsService;
 
+    Board board;
+
     @BeforeEach
     void setUp() {
         // 유저 생성
@@ -53,7 +55,7 @@ class FindPopularPostsServiceTest {
                 .build();
         categoryRepository.save(category);
 
-        Board board = Board.builder()
+        board = Board.builder()
                 .category(category)
                 .name("게시판 이름")
                 .build();
@@ -80,7 +82,7 @@ class FindPopularPostsServiceTest {
     @Test
     void success() {
         // 좋아요 내림차순으로 게시글들을 가져온다
-        List<PostWithUserDto> result = findPopularPostsService.findPopularPosts();
+        List<PostWithUserDto> result = findPopularPostsService.findPopularPosts(board.getId());
 
         // 좋아요가 0 보다 높은 값들만 가져오는지 확인
         // 좋아요 내림차순으로 가져오는지 확인

--- a/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/findpopularposts/FindPopularPostsServiceTest.java
@@ -1,0 +1,108 @@
+package com.nubble.backend.post.feature.findpopularposts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.feature.PostWithUserDto;
+import com.nubble.backend.post.fixture.PostFixture;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FindPopularPostsServiceTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FindPopularPostsService findPopularPostsService;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        User user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        // 게시글 생성
+        Category category = Category.builder()
+                .name("루트 카테고리")
+                .build();
+        categoryRepository.save(category);
+
+        Board board = Board.builder()
+                .category(category)
+                .name("게시판 이름")
+                .build();
+        boardRepository.save(board);
+
+        Post post1 = PostFixture.aPublishedPost()
+                .board(board)
+                .user(user).build();
+        Post post2 = PostFixture.aPublishedPost()
+                .board(board)
+                .user(user).build();
+        Post post3 = PostFixture.aPublishedPost()
+                .board(board)
+                .user(user).build();
+
+        // 리플렉션을 사용하여 likeCount 설정
+        setLikeCount(post1, 5);
+        setLikeCount(post2, 3);
+
+        postRepository.saveAll(List.of(post1, post2, post3));
+    }
+
+    @DisplayName("좋아요가 0 초과인 게시글들을 내림차순으로 가져온다")
+    @Test
+    void success() {
+        // 좋아요 내림차순으로 게시글들을 가져온다
+        List<PostWithUserDto> result = findPopularPostsService.findPopularPosts();
+
+        // 좋아요가 0 보다 높은 값들만 가져오는지 확인
+        // 좋아요 내림차순으로 가져오는지 확인
+        int prevLikeCount = Integer.MAX_VALUE;
+        for (PostWithUserDto postDto : result) {
+            int currentLikeCount = postDto.post().likeCount();
+
+            assertThat(currentLikeCount).isLessThanOrEqualTo(prevLikeCount);
+            assertThat(currentLikeCount).isPositive();
+
+            prevLikeCount = currentLikeCount;
+        }
+    }
+
+    private void setLikeCount(Post post, int likeCount) {
+        try {
+            Field likeCountField = post.getClass().getDeclaredField("likeCount");
+
+            likeCountField.setAccessible(true);
+            likeCountField.set(post, likeCount);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("reflection을 사용한 likeCount 값 설정을 실패하였습니다.");
+        }
+    }
+}

--- a/src/test/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailControllerTest.java
@@ -65,7 +65,8 @@ class GetPostDetailControllerTest {
                 .post(post)
                 .user(user)
                 .board(board)
-                .category(category).build();
+                .category(category)
+                .postLiked(true).build();
         GetPostWithUserQuery query = GetPostWithUserQuery.builder()
                 .postId(post.postId()).build();
         given(getPostDetailFacade.getPostDetailById(query))

--- a/src/test/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailFacadeTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/getpostdetail/GetPostDetailFacadeTest.java
@@ -1,5 +1,7 @@
 package com.nubble.backend.post.feature.getpostdetail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.nubble.backend.category.board.domain.Board;
 import com.nubble.backend.category.board.service.BoardInfo.BoardDto;
 import com.nubble.backend.category.board.service.BoardInfoMapper;
@@ -92,5 +94,6 @@ class GetPostDetailFacadeTest {
                 .isEqualTo(expectedBoardDto);
         CategoryDtoAssert.assertThat(actualResult.category())
                 .isEqualTo(expectedCategoryDto);
+        assertThat(actualResult.postLiked()).isFalse();
     }
 }

--- a/src/test/java/com/nubble/backend/post/feature/isliked/IsPostLikedServiceTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/isliked/IsPostLikedServiceTest.java
@@ -1,0 +1,99 @@
+package com.nubble.backend.post.feature.isliked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.post.feature.isliked.IsPostLikedService.IsPostLikedQuery;
+import com.nubble.backend.post.fixture.PostFixture;
+import com.nubble.backend.post.repository.PostLikeRepository;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import com.nubble.backend.utils.fixture.domain.BoardFixture;
+import com.nubble.backend.utils.fixture.domain.CategoryFixture;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class IsPostLikedServiceTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private IsPostLikedService isPostLikedService;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    private User user;
+    private Post publishedPost;
+
+    @BeforeEach
+    void setUp() {
+        Category category = CategoryFixture.aCategory().build();
+        categoryRepository.save(category);
+
+        Board board = BoardFixture.aBoard()
+                .category(category).build();
+        boardRepository.save(board);
+
+        user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        publishedPost = PostFixture.aPublishedPost()
+                .user(user)
+                .board(board).build();
+        postRepository.save(publishedPost);
+    }
+
+    @DisplayName("게시글에 좋아요를 눌렀다면 true를 반환한다")
+    @Test
+    void sucess_returnTrue() {
+        // 게시글 좋아요를 누른다
+        PostLike postLike = PostLike.builder()
+                .post(publishedPost)
+                .user(user).build();
+        postLikeRepository.save(postLike);
+
+        // 게시글 좋아요 검사
+        IsPostLikedQuery query = IsPostLikedQuery.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+        boolean result = isPostLikedService.isPostLiked(query);
+
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("게시글에 좋아요를 누르지 않았다면 false를 반환한다")
+    @Test
+    void sucess_returnFalse() {
+        // 게시글 좋아요 검사
+        IsPostLikedQuery query = IsPostLikedQuery.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+        boolean result = isPostLikedService.isPostLiked(query);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/nubble/backend/post/feature/like/LikePostControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/like/LikePostControllerTest.java
@@ -40,7 +40,7 @@ class LikePostControllerTest {
     private SessionRepository sessionRepository;
 
     @MockBean
-    private LikePostService likePostService;
+    private LikePostFacade likePostFacade;
 
     private Session session;
     private User user;
@@ -72,18 +72,18 @@ class LikePostControllerTest {
                 .postId(postId).build();
 
         long newLikeId = 102L;
-        given(likePostService.likePost(command))
+        given(likePostFacade.likePost(command))
                 .willReturn(newLikeId);
 
         // http response
         mockMvc.perform(requestBuilder)
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().json(String.format("""
+                .andExpect(content().json("""
                         {
                             "newLikeId": %d
                         }
-                        """, newLikeId)))
+                        """.formatted(newLikeId)))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/nubble/backend/post/feature/like/LikePostFacadeTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/like/LikePostFacadeTest.java
@@ -1,0 +1,80 @@
+package com.nubble.backend.post.feature.like;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nubble.backend.category.board.domain.Board;
+import com.nubble.backend.category.board.service.BoardRepository;
+import com.nubble.backend.category.domain.Category;
+import com.nubble.backend.category.service.CategoryRepository;
+import com.nubble.backend.post.domain.Post;
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
+import com.nubble.backend.post.fixture.PostFixture;
+import com.nubble.backend.post.repository.PostRepository;
+import com.nubble.backend.userold.domain.User;
+import com.nubble.backend.userold.service.UserRepository;
+import com.nubble.backend.utils.fixture.domain.BoardFixture;
+import com.nubble.backend.utils.fixture.domain.CategoryFixture;
+import com.nubble.backend.utils.fixture.domain.UserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class LikePostFacadeTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LikePostFacade likePostFacade;
+
+    private User user;
+    private Post publishedPost;
+
+    @BeforeEach
+    void setUp() {
+        Category category = CategoryFixture.aCategory().build();
+        categoryRepository.save(category);
+
+        Board board = BoardFixture.aBoard()
+                .category(category).build();
+        boardRepository.save(board);
+
+        user = UserFixture.aUser().build();
+        userRepository.save(user);
+
+        publishedPost = PostFixture.aPublishedPost()
+                .user(user)
+                .board(board).build();
+        postRepository.save(publishedPost);
+    }
+
+    @DisplayName("좋아요를 누르면 게시글의 좋아요수가 올라간다")
+    @Test
+    void success() {
+        // 게시글에 좋아요를 누른다
+        int prevLikeCount = publishedPost.getLikeCount();
+        LikePostCommand command = LikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+
+        likePostFacade.likePost(command);
+
+        // 게시글에 좋아요 개수가 올라간다
+        Post post = postRepository.getPostById(command.postId());
+        assertThat(post.getLikeCount()).isEqualTo(prevLikeCount + 1);
+    }
+}

--- a/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostControllerTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostControllerTest.java
@@ -38,7 +38,7 @@ class UnlikePostControllerTest {
     private SessionRepository sessionRepository;
 
     @MockBean
-    private UnlikePostService unlikePostService;
+    private UnlikePostFacade unlikePostFacade;
 
     private Session session;
     private User user;

--- a/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostFacadeTest.java
+++ b/src/test/java/com/nubble/backend/post/feature/unlinke/UnlikePostFacadeTest.java
@@ -1,11 +1,15 @@
 package com.nubble.backend.post.feature.unlinke;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.nubble.backend.category.board.domain.Board;
 import com.nubble.backend.category.board.service.BoardRepository;
 import com.nubble.backend.category.domain.Category;
 import com.nubble.backend.category.service.CategoryRepository;
 import com.nubble.backend.post.domain.Post;
-import com.nubble.backend.post.domain.PostLike;
+import com.nubble.backend.post.feature.like.LikePostFacade;
+import com.nubble.backend.post.feature.like.LikePostService;
+import com.nubble.backend.post.feature.like.LikePostService.LikePostCommand;
 import com.nubble.backend.post.feature.unlinke.UnlikePostService.UnlikePostCommand;
 import com.nubble.backend.post.fixture.PostFixture;
 import com.nubble.backend.post.repository.PostLikeRepository;
@@ -15,18 +19,16 @@ import com.nubble.backend.userold.service.UserRepository;
 import com.nubble.backend.utils.fixture.domain.BoardFixture;
 import com.nubble.backend.utils.fixture.domain.CategoryFixture;
 import com.nubble.backend.utils.fixture.domain.UserFixture;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-class UnlikePostServiceTest {
+class UnlikePostFacadeTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
@@ -41,10 +43,16 @@ class UnlikePostServiceTest {
     private UserRepository userRepository;
 
     @Autowired
-    private PostLikeRepository postLikeRepository;
+    private LikePostFacade likePostFacade;
 
     @Autowired
-    private UnlikePostService unlikePostService;
+    private UnlikePostFacade unlikePostFacade;
+
+    @Autowired
+    private LikePostService likePostService;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
 
     private User user;
     private Post publishedPost;
@@ -70,34 +78,42 @@ class UnlikePostServiceTest {
     @DisplayName("좋아요를 취소한다")
     @Test
     void success() {
-        // 좋아요를 한다
-        PostLike postLike = PostLike.builder()
-                .post(publishedPost)
-                .user(user).build();
-        Long postLikeId = postLikeRepository.save(postLike).getId();
+        // 좋아요를 누른다
+        LikePostCommand likePostCommand = LikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+        likePostFacade.likePost(likePostCommand);
 
         // 좋아요를 취소한다
-        UnlikePostCommand command = UnlikePostCommand.builder()
+        UnlikePostCommand unlikePostCommand = UnlikePostCommand.builder()
                 .postId(publishedPost.getId())
                 .userId(user.getId()).build();
+        unlikePostFacade.unlikePost(unlikePostCommand);
 
-        unlikePostService.unlikePost(command);
-
-        // 좋아요 취소를 확인한다
-        Assertions.assertThat(postLikeRepository.findById(postLikeId)).isEmpty();
+        // 취소되었는지 확인
+        Post post = postRepository.getPostById(publishedPost.getId());
+        assertThat(post.getLikeCount()).isZero();
     }
 
-    @DisplayName("좋아요를 누른 적이 없다면, 취소할 수 없다")
+    @DisplayName("좋아요가 0이하로 내려가지 않는다")
     @Test
-    void throwException() {
-        // 좋아요 취소를 한다
-        // 좋아요 한 적이 없으므로 예외를 발생시킨다
-        UnlikePostCommand command = UnlikePostCommand.builder()
+    void not_fall_below_zero() {
+        // 강제로 좋아요는 누르지만, 좋아요 카운트는 증가시키지 않는다
+        LikePostCommand likePostCommand = LikePostCommand.builder()
                 .postId(publishedPost.getId())
                 .userId(user.getId()).build();
+        Long postLikeId = likePostService.likePost(likePostCommand);
 
-        Assertions.assertThatThrownBy(() -> unlikePostService.unlikePost(command))
-                .isInstanceOf(JpaObjectRetrievalFailureException.class)
-                .hasMessage("좋아요가 존재하지 않습니다.");
+        assertThat(postLikeRepository.findById(postLikeId)).isPresent();
+        assertThat(postRepository.getPostById(publishedPost.getId()).getLikeCount()).isZero();
+
+        // 좋아요를 취소해도 0이하로 떨어지지 않는다
+        UnlikePostCommand unlikePostCommand = UnlikePostCommand.builder()
+                .postId(publishedPost.getId())
+                .userId(user.getId()).build();
+        unlikePostFacade.unlikePost(unlikePostCommand);
+
+        assertThat(postLikeRepository.findById(postLikeId)).isEmpty();
+        assertThat(postRepository.getPostById(publishedPost.getId()).getLikeCount()).isZero();
     }
 }

--- a/src/test/java/com/nubble/backend/post/fixture/PostDtoFixture.java
+++ b/src/test/java/com/nubble/backend/post/fixture/PostDtoFixture.java
@@ -16,6 +16,7 @@ public class PostDtoFixture {
     private LocalDateTime createdAt;
     private Long userId;
     private Long boardId;
+    private int likeCount;
 
     public static PostDtoFixture aPostDto() {
         PostDtoFixture fixture = new PostDtoFixture();
@@ -47,6 +48,11 @@ public class PostDtoFixture {
         return this;
     }
 
+    public PostDtoFixture likeCount(int likeCount) {
+        this.likeCount = likeCount;
+        return this;
+    }
+
     public PostDto build() {
         return builder.postId(postId)
                 .title(title)
@@ -56,6 +62,7 @@ public class PostDtoFixture {
                 .status(status)
                 .createdAt(createdAt)
                 .userId(userId)
-                .boardId(boardId).build();
+                .boardId(boardId)
+                .likeCount(likeCount).build();
     }
 }


### PR DESCRIPTION
## 인기 게시글 조회

- 게시글 1 이상 게시글만 조회해옵니다.
-  게시글 좋아요 내림차순으로 반환합니다.

### 요청
```http
GET /boards/{boardId}/posts/popular HTTP/1.1
Host: localhost:8080
Accept: application/json
```

### 응답
```http
{
  "posts": [
    {
      "id": 1,
      "title": "Popular Post Title 1",
      "thumbnailUrl": "http://example.com/thumbnail1.jpg",
      "description": "Description of the first popular post",
      "username": "user1",
      "createdAt": "2023-10-01T12:00:00",
      "likeCount": 10
    },
    {
      "id": 2,
      "title": "Popular Post Title 2",
      "thumbnailUrl": "http://example.com/thumbnail2.jpg",
      "description": "Description of the second popular post",
      "username": "user2",
      "createdAt": "2023-10-02T15:30:00",
      "likeCount": 8
    },
    {
      "id": 3,
      "title": "Popular Post Title 3",
      "thumbnailUrl": "http://example.com/thumbnail3.jpg",
      "description": "Description of the third popular post",
      "username": "user3",
      "createdAt": "2023-10-03T09:15:00",
      "likeCount": 5
    }
    // 추가 게시글 데이터...
  ]
}
```

## 추가 반영사항

- 게시글 좋아요 시, 게시글의 좋아요 카운트를 증가시킵니다.
- 게시글 좋아요 취소 시, 게시글의 좋아요 카운트를 감소시킵니다.
- 게시글 상세 조회와 게시글 리스트 시에도 좋아요 개수를 알려줍니다.
- 게시글 상세 조회 시, 유저의 좋아요 유무를 알려줍니다.